### PR TITLE
Fix errors and deprecations (2022-04-13)

### DIFF
--- a/src/main/react/features/assignments/AssignmentFeature.tsx
+++ b/src/main/react/features/assignments/AssignmentFeature.tsx
@@ -1,8 +1,8 @@
-import React, {useState} from "react";
-import {AssignmentList} from "./AssignmentList";
-import {AssignmentDialog} from "./AssignmentDialog";
-import {Card, CardContent, CardHeader} from "@material-ui/core";
-import {Person} from "../../clients/PersonClient";
+import React, { useState } from "react";
+import { AssignmentList } from "./AssignmentList";
+import { AssignmentDialog } from "./AssignmentDialog";
+import { Card, CardContent, CardHeader } from "@material-ui/core";
+import { Person } from "../../clients/PersonClient";
 import Button from "@material-ui/core/Button";
 import AddIcon from "@material-ui/icons/Add";
 

--- a/src/main/react/features/client/ClientForm.tsx
+++ b/src/main/react/features/client/ClientForm.tsx
@@ -51,7 +51,8 @@ export function ClientForm({ code, value, onSubmit }: ClientFormProps) {
       onSubmit={handleSubmit}
       validationSchema={schema}
       enableReinitialize
-      render={form}
-    />
+    >
+      {form}
+    </Formik>
   );
 }

--- a/src/main/react/features/contract/ContractFormExternal.tsx
+++ b/src/main/react/features/contract/ContractFormExternal.tsx
@@ -4,8 +4,8 @@ import { Grid } from "@material-ui/core";
 import { Field, Form, Formik } from "formik";
 import { MuiPickersUtilsProvider } from "@material-ui/pickers";
 import MomentUtils from "@date-io/moment";
-import { TextField, CheckboxWithLabel } from "formik-material-ui";
-import { mixed, number, object, boolean } from "yup";
+import { CheckboxWithLabel, TextField } from "formik-material-ui";
+import { boolean, mixed, number, object } from "yup";
 import moment from "moment";
 import { DatePickerField } from "../../components/fields/DatePickerField";
 
@@ -65,7 +65,6 @@ export const ContractFormExternal = ({
               type="checkbox"
               Label={{ label: "Billable" }}
               component={CheckboxWithLabel}
-              fullWidth
             />
           </Grid>
         </Grid>

--- a/src/main/react/features/contract/ContractFormInternal.tsx
+++ b/src/main/react/features/contract/ContractFormInternal.tsx
@@ -5,7 +5,7 @@ import { Field, Form, Formik } from "formik";
 import { MuiPickersUtilsProvider } from "@material-ui/pickers";
 import MomentUtils from "@date-io/moment";
 import { CheckboxWithLabel, TextField } from "formik-material-ui";
-import { mixed, number, object, boolean } from "yup";
+import { boolean, mixed, number, object } from "yup";
 import moment from "moment";
 import { DatePickerField } from "../../components/fields/DatePickerField";
 
@@ -65,7 +65,6 @@ export const ContractFormInternal = ({
               type="checkbox"
               Label={{ label: "Billable" }}
               component={CheckboxWithLabel}
-              fullWidth
             />
           </Grid>
           <Grid item xs={12}>

--- a/src/main/react/features/month/MonthFeature.tsx
+++ b/src/main/react/features/month/MonthFeature.tsx
@@ -1,6 +1,11 @@
-import React, { useEffect, useState } from "react";
+import React, { Fragment, useEffect, useState } from "react";
 import Typography from "@material-ui/core/Typography";
-import { CardContent } from "@material-ui/core";
+import {
+  CardContent,
+  TableBody,
+  TableContainer,
+  TableHead,
+} from "@material-ui/core";
 import Card from "@material-ui/core/Card";
 import moment from "moment";
 import IconButton from "@material-ui/core/IconButton";
@@ -131,38 +136,44 @@ export function MonthFeature() {
   };
 
   const renderOverview = () =>
-    clientHourOverviewState.map((it) => (
-      <>
+    clientHourOverviewState.map((it, clientIndex) => (
+      <Fragment key={clientIndex}>
         <Typography variant="h6">{it.client.name}</Typography>
-        <Table>
-          <TableRow>
-            <TableCell />
-            {dayRange?.map((day) => (
-              <TableCell>
-                <b>{day}</b>
-              </TableCell>
-            ))}
-          </TableRow>
-          {it.aggregationPerson.map((person) => (
-            <TableRow>
-              <TableCell>{person.person.name}</TableCell>
-              {person.hours.map((val) => (
-                <TableCell width={10}>
-                  {val > 0 ? val.toFixed(1) : "-"}
-                </TableCell>
+        <TableContainer>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell />
+                {dayRange?.map((day, dayIndex) => (
+                  <TableCell key={dayIndex}>
+                    <b>{day}</b>
+                  </TableCell>
+                ))}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {it.aggregationPerson.map((person, personIndex) => (
+                <TableRow key={personIndex}>
+                  <TableCell>{person.person.name}</TableCell>
+                  {person.hours.map((val, personHoursIndex) => (
+                    <TableCell width={10} key={personHoursIndex}>
+                      {val > 0 ? val.toFixed(1) : "-"}
+                    </TableCell>
+                  ))}
+                </TableRow>
               ))}
-            </TableRow>
-          ))}
-          <TableRow>
-            <TableCell>Totals</TableCell>
-            {it.totals.map((val) => (
-              <TableCell>
-                <b>{val.toFixed(1)}</b>
-              </TableCell>
-            ))}
-          </TableRow>
-        </Table>
-      </>
+              <TableRow>
+                <TableCell>Totals</TableCell>
+                {it.totals.map((val, dayTotalIndex) => (
+                  <TableCell key={dayTotalIndex}>
+                    <b>{val.toFixed(1)}</b>
+                  </TableCell>
+                ))}
+              </TableRow>
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Fragment>
     ));
 
   return (

--- a/src/main/react/features/person/PersonDialog.tsx
+++ b/src/main/react/features/person/PersonDialog.tsx
@@ -9,7 +9,7 @@ import { DialogFooter, DialogHeader } from "../../components/dialog";
 type PersonDialogProps = {
   open: boolean;
   onClose: () => void;
-  item: any;
+  item?: any;
 };
 export const PersonDialog = ({ open, onClose, item }: PersonDialogProps) => {
   const successfulSubmit = () => {

--- a/src/main/react/features/person/table/PersonTable.tsx
+++ b/src/main/react/features/person/table/PersonTable.tsx
@@ -34,7 +34,7 @@ export const PersonTable = () => {
   const { url } = useRouteMatch();
   const [page, setPage] = useState(0);
   const [size, setSize] = useState(10);
-  const [count, setCount] = useState(10);
+  const [count, setCount] = useState(-1);
   const [personList, setPersonList] = useState<Person[]>([]);
   const [dialog, setDialog] = useState({ open: false });
   const [reload, setReload] = useState(false);
@@ -45,7 +45,8 @@ export const PersonTable = () => {
     // eslint-disable-next-line no-shadow
     PersonClient.findAllByPage({ page, size, sort: "lastname" }).then((res) => {
       setPersonList(res.list);
-      setCount(res.total);
+      // FIXME: No total count in response
+      // setCount(res.total);
     });
   }, [reload, page, size]);
 
@@ -58,11 +59,11 @@ export const PersonTable = () => {
     setDialog({ open: false });
   };
 
-  const handleChangePage = (_, newPage) => {
+  const handlePageChange = (_, newPage) => {
     setPage(newPage);
   };
 
-  const handleChangeRowsPerPage = (event) => {
+  const handleRowsPerPageChange = (event) => {
     const rowsPerPage = event.target.value;
     setSize(+rowsPerPage);
     setPage(0);
@@ -95,9 +96,9 @@ export const PersonTable = () => {
                     <TableCell align="left">
                       {person.active && <CheckBox />}
                     </TableCell>
-                    <TableCell align="left">{person.holidays}</TableCell>
-                    <TableCell align="left">{person.clients}</TableCell>
-                    <TableCell align="left">{person.hours}</TableCell>
+                    <TableCell />
+                    <TableCell />
+                    <TableCell />
                   </TableRow>
                 );
               })}
@@ -109,11 +110,11 @@ export const PersonTable = () => {
           component="div"
           count={count}
           // remove labelDisplayRows by replacing it with an empty return
-          labelDisplayedRows={() => {}}
+          labelDisplayedRows={() => null}
           rowsPerPage={size}
           page={page}
-          onChangePage={handleChangePage}
-          onChangeRowsPerPage={handleChangeRowsPerPage}
+          onPageChange={handlePageChange}
+          onRowsPerPageChange={handleRowsPerPageChange}
         />
       </Paper>
       <PersonDialog open={dialog.open} onClose={handleDialogClose} />

--- a/src/main/react/features/person/table/PersonTableHead.tsx
+++ b/src/main/react/features/person/table/PersonTableHead.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { TableHead, TableRow, TableCell } from "@material-ui/core";
+import { TableCell, TableHead, TableRow } from "@material-ui/core";
 
 const headCells = [
   {
@@ -43,7 +43,7 @@ export const PersonTableHead = () => {
           <TableCell
             key={cell.id}
             align={cell.algin ? "right" : "left"}
-            padding={cell.disablePadding ? "none" : "default"}
+            padding={cell.disablePadding ? "none" : "normal"}
           >
             {cell.label}
           </TableCell>


### PR DESCRIPTION
- Imports
- Formik render form method (deprecation)
- Remove fullWidth from elements that don't support it
- Add keys to repeating child elements
- Fix table nesting
- Hardcode count to -1 in pagination where pagination info is not available (according to MUI docs)
- Use handleXChange instead of handleChangeX (deprecation)
- Use padding="normal" instead of "default" (deprecation)
- Make optional props optional in TS type for PersonDialog