### PR TITLE
Move add and edit logic inside AssignmentFeature component

### DIFF
--- a/src/main/react/features/assignments/AssignmentFeature.tsx
+++ b/src/main/react/features/assignments/AssignmentFeature.tsx
@@ -5,13 +5,14 @@ import { Card, CardContent, CardHeader } from "@material-ui/core";
 import { Person } from "../../clients/PersonClient";
 import Button from "@material-ui/core/Button";
 import AddIcon from "@material-ui/icons/Add";
+import UserAuthorityUtil from "@flock-community/flock-eco-feature-user/src/main/react/user_utils/UserAuthorityUtil";
 
 type AssignmentFeatureProps = {
   person: Person,
-  disableEdit: boolean
 };
 
-export function AssignmentFeature({ person, disableEdit = false }: AssignmentFeatureProps) {
+export function AssignmentFeature({ person }: AssignmentFeatureProps) {
+  const hasWriteAuthority = UserAuthorityUtil.hasAuthority("AssignmentAuthority.WRITE")
   const [reload, setReload] = useState(true);
   const [dialog, setDialog] = useState({ open: false, code: null });
 
@@ -33,7 +34,7 @@ export function AssignmentFeature({ person, disableEdit = false }: AssignmentFea
       <Card>
         <CardHeader
           title="Assignments"
-          action={!disableEdit &&
+          action={hasWriteAuthority &&
             <Button onClick={handleClickAdd}>
               <AddIcon /> Add
             </Button>
@@ -44,7 +45,7 @@ export function AssignmentFeature({ person, disableEdit = false }: AssignmentFea
             personId={person?.uuid}
             onItemClick={handleItemClick}
             reload={reload}
-            disableEdit={disableEdit}
+            disableEdit={!hasWriteAuthority}
           />
         </CardContent>
       </Card>

--- a/src/main/react/features/assignments/AssignmentPage.tsx
+++ b/src/main/react/features/assignments/AssignmentPage.tsx
@@ -1,15 +1,11 @@
 import { AssignmentFeature } from "./AssignmentFeature";
 import React from "react";
 import PersonLayout from "../../components/layouts/PersonLayout";
-import UserAuthorityUtil from "@flock-community/flock-eco-feature-user/src/main/react/user_utils/UserAuthorityUtil";
 
 export default function AssignmentPage() {
   return (
     <PersonLayout requireAuthority={"AssignmentAuthority.ADMIN"}>
-      {(person) => <AssignmentFeature person={person}
-                                      disableEdit={
-                                        !UserAuthorityUtil.hasAuthority("AssignmentAuthority.WRITE")
-                                      }/>}
+      {(person) => <AssignmentFeature person={person} />}
     </PersonLayout>
   );
 }

--- a/src/main/react/features/person/PersonDetails.tsx
+++ b/src/main/react/features/person/PersonDetails.tsx
@@ -77,7 +77,7 @@ export const PersonDetails = (props) => {
 
   const assignments = (
     <Grid item xs={12} sm={6}>
-      <AssignmentFeature person={person}  disableEdit/>
+      <AssignmentFeature person={person} />
     </Grid>
   );
 


### PR DESCRIPTION
https://flock.atlassian.net/browse/WRK-53

The 'ADD' button is now available on the persons page. I moved the logic of the disableEdit into the component as it was only used in 2 places and then changed it. One of these places was disabled by default and the ticket wanted it to be not disabled.

I tried to find a situation where I would have no write authority, and could only do it by going to '/assignments' path when I was on a user account. Arguably I shouldn't have been able to see the page all together.

![Screenshot 2023-04-05 at 10 08 50](https://user-images.githubusercontent.com/49371690/230020823-4ee710ff-fd1c-4438-a598-ea5adc5c664a.png)
