### PR TITLE
Setup 'empty' oathkeeper to act as a noop proxy towards workday

### DIFF
--- a/.github/workflows/gcp.yml
+++ b/.github/workflows/gcp.yml
@@ -55,3 +55,12 @@ jobs:
 
       - name: Build and Deploy Development version
         run: ./mvnw -B compile -P develop -P frontend jib:build -Djib.container.environment=SPRING_PROFILES_ACTIVE=develop -Djib.to.image=gcr.io/flock-eco/flock-eco-workday-develop --file pom.xml
+
+      - id: build-and-push-oathkeeper
+        name: Build and push Oathkeeper
+        uses: docker/build-push-action@v3
+        with:
+          context: deployments/oathkeeper
+          push: true
+          tags: eu.gcr.io/flock-eco/flock-eco-workday-oathkeeper:develop
+

--- a/.github/workflows/gcp.yml
+++ b/.github/workflows/gcp.yml
@@ -62,5 +62,5 @@ jobs:
         with:
           context: deployments/oathkeeper
           push: true
-          tags: eu.gcr.io/flock-eco/flock-eco-workday-oathkeeper:develop
+          tags: gcr.io/flock-eco/flock-eco-workday-oathkeeper:develop
 

--- a/deployments/oathkeeper/Dockerfile
+++ b/deployments/oathkeeper/Dockerfile
@@ -1,0 +1,5 @@
+FROM oryd/oathkeeper:v0.40.3
+LABEL organization="Flock. community"
+LABEL audience="Flock. community Workday app"
+
+COPY ./config /home/ory/config

--- a/deployments/oathkeeper/config/config.yaml
+++ b/deployments/oathkeeper/config/config.yaml
@@ -1,0 +1,97 @@
+serve:
+  proxy:
+    port: 4455
+    cors:
+      enabled: true
+      allowed_origins:
+        - https://accounts.flock.community
+        - https://shadow.accounts.flock.community
+      allowed_methods:
+        - POST
+        - GET
+        - PUT
+        - PATCH
+        - DELETE
+      allowed_headers:
+        - Authorization
+        - Content-Type
+      exposed_headers:
+        - Content-Type
+      allow_credentials: true
+      debug: true
+  api:
+    port: 4456
+  prometheus:
+    port: 9000
+    metrics_path: /metrics
+
+log:
+  level: debug
+  format: json
+  leak_sensitive_values: false
+
+
+access_rules:
+  repositories:
+    - file:///home/ory/config/rules.yaml
+
+errors:
+  fallback:
+    - json
+  handlers:
+    redirect:
+      enabled: true
+      config:
+        to: https://accounts.flock.community/ui/login
+        return_to_query_param: return_to
+        when:
+          - error:
+              - unauthorized
+              # - forbidden
+            request:
+              header:
+                accept:
+                  - text/html
+    json:
+      enabled: true
+      config:
+        verbose: true
+
+mutators:
+  noop:
+    enabled: true
+  id_token:
+    # Set enabled to true if the authenticator should be enabled and false to disable the authenticator. Defaults to false.
+    enabled: false
+  header:
+    enabled: true
+    config:
+      headers:
+        X-User: "{{ print .Subject }}"
+        X-Email: "{{ print .Extra.identity.traits.email }}"
+        X-Authenticator-Assurance-Level: "{{ print .Extra.authenticator_assurance_level }}"
+
+authorizers:
+  allow:
+    enabled: true
+  deny:
+    enabled: true
+
+authenticators:
+  noop:
+    enabled: true
+  unauthorized:
+    enabled: true
+  anonymous:
+    enabled: true
+    config:
+      subject: guest
+  cookie_session:
+    enabled: true
+    config:
+      check_session_url: https://accounts.flock.community/sessions/whoami
+      preserve_path: true
+      extra_from: "@this"
+      subject_from: "identity.id"
+      only:
+        - flock_community_session

--- a/deployments/oathkeeper/config/rules/rules.yaml
+++ b/deployments/oathkeeper/config/rules/rules.yaml
@@ -1,0 +1,39 @@
+- id: workday-everything
+  upstream:
+    url: https://host.docker.internal:8080
+  version: v0.40.3
+  match:
+    url: https://workday.flock.community/<.*>
+    methods:
+      - GET
+      - POST
+      - PUT
+      - DELETE
+  authenticators:
+    - handler: noop
+  authorizer:
+    handler: allow
+  mutators:
+    - handler: noop
+  errors:
+    - handler: json
+
+- id: shadow-workday-everything
+  upstream:
+    url: https://host.docker.internal:8080
+  version: v0.40.3
+  match:
+    url: https://shadow.workday.flock.community/<.*>
+    methods:
+      - GET
+      - POST
+      - PUT
+      - DELETE
+  authenticators:
+    - handler: noop
+  authorizer:
+    handler: allow
+  mutators:
+    - handler: noop
+  errors:
+    - handler: json

--- a/deployments/oathkeeper/config/rules/rules.yaml
+++ b/deployments/oathkeeper/config/rules/rules.yaml
@@ -1,6 +1,6 @@
 - id: workday-everything
   upstream:
-    url: https://host.docker.internal:8080
+    url: https://workday-app-x6nsuevzyq-ew.a.run.app
   version: v0.40.3
   match:
     url: https://workday.flock.community/<.*>
@@ -20,10 +20,10 @@
 
 - id: shadow-workday-everything
   upstream:
-    url: https://host.docker.internal:8080
+    url: https://workday-app-ory-x6nsuevzyq-ew.a.run.app
   version: v0.40.3
   match:
-    url: https://shadow.workday.flock.community/<.*>
+    url: https://ory.workday.flock.community/<.*>
     methods:
       - GET
       - POST


### PR DESCRIPTION
With this setup, Workday is preparing for authentication and authorization outisde of the app itself, but managed through Ory's Oathkeeper, and identity aware access proxy.


```
internet --> oathkeeper --> workday
         <---           <---
```

To give some context to what is happening and why. We have a grant master plan to take all authentication and authorization from the spring app, and do this in decidated service in front of WDA: [Link to grant master plan]( https://github.com/flock-community/flock-eco-workday/blob/10f9305b524fbcfb2a7a7be96e6f4a0a0030268c/docs/identity-access-management.md)
<img width="852" alt="image" src="https://github.com/flock-community/flock-eco-workday/assets/4041699/68a721ea-9398-45c0-83ad-649a8ea81d1d">

