### PR TITLE
Fix path to oathkeeper rules

### DIFF
--- a/deployments/oathkeeper/config/config.yaml
+++ b/deployments/oathkeeper/config/config.yaml
@@ -33,7 +33,7 @@ log:
 
 access_rules:
   repositories:
-    - file:///home/ory/config/rules.yaml
+    - file:///home/ory/config/rules/rules.yaml
 
 errors:
   fallback:


### PR DESCRIPTION
Added the `rules` folder to this config, so the setup oathkeeper rules are found by the oathkeeper config.

faulty config:
```yaml
access_rules:
  repositories:
    - file:///home/ory/config/rules.yaml
```