### PR TITLE
refactor: Improve use of PersoonHook in Application root

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+--add-opens java.base/java.lang=ALL-UNNAMED

--- a/src/main/react/application/Application.tsx
+++ b/src/main/react/application/Application.tsx
@@ -15,7 +15,6 @@ import { ApplicationDrawer } from "./ApplicationDrawer";
 import { HomeFeature } from "../features/home/HomeFeature";
 import { ClientFeature } from "../features/client/ClientFeature";
 import { PersonFeature } from "../features/person/PersonFeature";
-import { useUserMe } from "../hooks/UserMeHook";
 import { DashboardFeature } from "../features/dashboard/DashboardFeature";
 import { MonthFeature } from "../features/month/MonthFeature";
 import { EventFeature } from "../features/event/EventFeature";
@@ -38,13 +37,20 @@ import AssignmentReport from "../features/report/Assignment/AssignmentReport";
 import ContractOverview from "../features/report/ContractOverview/ContractOverview";
 import AssignmentOverview from "../features/report/AssignmentOverview/AssignmentOverview";
 import { LoginFeature } from "../features/login/LoginFeature";
-import {usePerson} from "../hooks/PersonHook";
 
 const theme = getTheme("light");
 
 export const Application = () => {
   const status = useLoginStatus();
   const errors = useError();
+
+  useEffect(() => {
+    if (status) {
+      UserAuthorityUtil.setAuthorities(status.authorities);
+    } else {
+      UserAuthorityUtil.setAuthorities([]);
+    }
+  }, [status]);
 
   if (status == null) {
     return <AlignedLoader/>;
@@ -53,69 +59,55 @@ export const Application = () => {
   return (
     <Router>
       <ThemeProvider theme={theme}>
-        { status.isLoggedIn ? <RenderAuthenticated status={status} /> : <RenderUnauthenticated />}
-          <ErrorStack ErrorList={errors}/>
+        {status.isLoggedIn ? (
+          <RenderAuthenticated />
+        ) : (
+          <RenderUnauthenticated />
+        )}
+        <ErrorStack ErrorList={errors} />
       </ThemeProvider>
     </Router>
   );
 };
 
-const RenderAuthenticated = ({status}) => {
-  const [ person, handlePerson ] = usePerson();
-  const [ user, handleUser ] = useUserMe();
-
-  useEffect(() => {
-    if (status) {
-      UserAuthorityUtil.setAuthorities(status.authorities);
-      handlePerson(status.personId);
-      handleUser(status.userId);
-    }
-  }, [status]);
-
+const RenderAuthenticated = () => {
   const [openDrawer, setOpenDrawer] = useState(false);
 
-  return <>
-    <ApplicationDrawer
-      open={openDrawer}
-      onClose={() => setOpenDrawer(false)}
-    />
-    <ApplicationLayout onDrawer={() => setOpenDrawer(true)}/>
+  return (
+    <>
+      <ApplicationDrawer
+        open={openDrawer}
+        onClose={() => setOpenDrawer(false)}
+      />
+      <ApplicationLayout onDrawer={() => setOpenDrawer(true)} />
       <Switch>
-        <Route path="/" exact component={HomeFeature}/>
-        <Route path="/dashboard" exact component={DashboardFeature}/>
-        <Route path="/month" exact component={MonthFeature}/>
-        <Route path="/todo" exact component={TodoFeature}/>
-        <Route path="/clients" exact component={ClientFeature}/>
-        <Route path="/contracts" exact component={ContractPage}/>
-        <Route path="/projects" exact component={ProjectFeature}/>
-        <Route path="/assignments" exact component={AssignmentPage}/>
-        <Route path="/workdays" exact component={WorkDayPage}/>
-        <Route path="/leave-days" exact component={LeaveDayPage}/>
-        <Route path="/sickdays" component={SickDayPage}/>
-        <Route path="/expenses" component={ExpensePage}/>
-        <Route path="/exactonline" component={ExactonlineFeature}/>
-        <Route path="/users" exact component={UserFeature}/>
-        <Route path="/person" component={PersonFeature}/>
-        <Route path="/event" component={EventFeature}/>
-        <Route
-          path="/event_rating/:eventCode"
-          component={EventRatingFeature}
-        />
-        <Route
-          path="/reports/assignment"
-          component={AssignmentReport}
-        />
-        <Route
-          path="/reports/contract-overview"
-          component={ContractOverview}
-        />
+        <Route path="/" exact component={HomeFeature} />
+        <Route path="/dashboard" exact component={DashboardFeature} />
+        <Route path="/month" exact component={MonthFeature} />
+        <Route path="/todo" exact component={TodoFeature} />
+        <Route path="/clients" exact component={ClientFeature} />
+        <Route path="/contracts" exact component={ContractPage} />
+        <Route path="/projects" exact component={ProjectFeature} />
+        <Route path="/assignments" exact component={AssignmentPage} />
+        <Route path="/workdays" exact component={WorkDayPage} />
+        <Route path="/leave-days" exact component={LeaveDayPage} />
+        <Route path="/sickdays" component={SickDayPage} />
+        <Route path="/expenses" component={ExpensePage} />
+        <Route path="/exactonline" component={ExactonlineFeature} />
+        <Route path="/users" exact component={UserFeature} />
+        <Route path="/person" component={PersonFeature} />
+        <Route path="/event" component={EventFeature} />
+        <Route path="/event_rating/:eventCode" component={EventRatingFeature} />
+        <Route path="/reports/assignment" component={AssignmentReport} />
+        <Route path="/reports/contract-overview" component={ContractOverview} />
         <Route
           path="/reports/assignment-overview"
           component={AssignmentOverview}
         />
-        <Redirect to="/"/>
+        <Redirect to="/" />
       </Switch>
-  </>
+    </>
+  );
 };
 
 const RenderUnauthenticated = () => {

--- a/src/main/react/clients/BootstrapClient.ts
+++ b/src/main/react/clients/BootstrapClient.ts
@@ -1,17 +1,23 @@
 import {
   checkResponse,
   validateResponse,
-} from "@flock-community/flock-eco-core/src/main/react/clients/utils.ts";
+} from "@flock-community/flock-eco-core/src/main/react/clients/utils";
 
 const path = "/bootstrap";
 
+export type BootstrapData = {
+  authorities: string[];
+  isLoggedIn: boolean;
+  userId?: string;
+  personId?: string;
+};
 const getBootstrap = () => {
   const opts = {
     method: "GET",
   };
 
   return fetch(`${path}`, opts)
-    .then(validateResponse)
+    .then(validateResponse<BootstrapData>)
     .then(checkResponse)
     .then((res) => res.body);
 };

--- a/src/main/react/hooks/PersonHook.ts
+++ b/src/main/react/hooks/PersonHook.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { SetStateAction, useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import { Person, PersonClient } from "../clients/PersonClient";
 import { useLoginStatus } from "./StatusHook";
@@ -18,7 +18,7 @@ export function usePerson(): [Person | null, (personId: string) => void] {
   const [state, setState] = useState(store);
 
   useEffect(() => {
-    const listener = (it) => setState(it);
+    const listener = (it: SetStateAction<Person | null>) => setState(it);
     if (store === null && listeners.length === 0) {
       if (status && status.isLoggedIn) {
         PersonClient.me().then(update);

--- a/src/main/react/hooks/StatusHook.ts
+++ b/src/main/react/hooks/StatusHook.ts
@@ -1,20 +1,20 @@
-import { useEffect, useState } from "react";
-import { BootstrapClient } from "../clients/BootstrapClient";
+import { SetStateAction, useEffect, useState } from "react";
+import { BootstrapClient, BootstrapData } from "../clients/BootstrapClient";
 
 // eslint-disable-next-line import/no-mutable-exports
-export let store = null;
-const listeners = [];
+export let store: BootstrapData | null = null;
+const listeners: ((block: BootstrapData | null) => void)[] = [];
 
-function update(it) {
+const update = (it: BootstrapData | null) => {
   store = it;
   listeners.forEach((func) => func(it));
-}
+};
 
 export function useLoginStatus() {
   const [state, setState] = useState(store);
 
   useEffect(() => {
-    const listener = (it) => setState(it);
+    const listener = (it: SetStateAction<BootstrapData | null>) => setState(it);
     if (store === null && listeners.length === 0) {
       BootstrapClient.getBootstrap().then(update);
     }


### PR DESCRIPTION
As part of https://github.com/flock-community/flock-eco-workday/pull/343, the bootstrapclient was introduced, simplifying the bootstrapping flow during fe application load.

GEThere was some room for improvement to prevent calling the `GET /api/persons/{id} ` endpoint multiple times. That's what this PR addresses