### PR TITLE
chore: fix pom.xml duplication warning build-helper-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,24 +205,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>add-test-source</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>add-test-source</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>src/it/kotlin</source>
-                            </sources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <version>2.7.1</version>
@@ -244,6 +226,18 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>
+                    <execution>
+                        <id>add-test-source</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/it/kotlin</source>
+                            </sources>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>add-resource-database</id>
                         <phase>generate-resources</phase>
@@ -306,7 +300,7 @@
                                     <goal>npm</goal>
                                 </goals>
                                 <configuration>
-                                    <arguments>ci</arguments>
+                                    <arguments>install</arguments>
                                 </configuration>
                             </execution>
                             <execution>


### PR DESCRIPTION
Fixes the following warning:

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for flock.community.eco.workday:flock-eco-workday:jar:develop-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.codehaus.mojo:build-helper-maven-plugin @ line 243, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```