### PR TITLE
Fix issue with expense uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@babel/preset-react": "^7.23.3",
         "@babel/preset-typescript": "^7.23.3",
         "@flock-community/flock-eco-webpack": "^2.8.0",
-        "@flock/wirespec": "^0.8.51",
+        "@flock/wirespec": "0.8.46",
         "@fontsource/material-icons": "^5.0.7",
         "@fontsource/roboto": "^5.0.8",
         "@storybook/addon-themes": "^7.5.3",
@@ -3083,9 +3083,9 @@
       }
     },
     "node_modules/@flock/wirespec": {
-      "version": "0.8.51",
-      "resolved": "https://registry.npmjs.org/@flock/wirespec/-/wirespec-0.8.51.tgz",
-      "integrity": "sha512-U5OvDN5xYyKBxFttLT51LZNUmuVvRRtfqwqC+4cmDr9p5MwX7tEw2OZQqcynbbJeflFPUsqfts76pFqf9iUaaw==",
+      "version": "0.8.46",
+      "resolved": "https://registry.npmjs.org/@flock/wirespec/-/wirespec-0.8.46.tgz",
+      "integrity": "sha512-mH2wg0W+qoWB0UbD3TlpPaRYOcrf+5oJxi88AdcvdvFnw597nKC5pTvF9lUSH9VrszT976yLxlXQPjGyB4MK8w==",
       "dev": true,
       "dependencies": {
         "format-util": "^1.0.5"
@@ -41809,9 +41809,9 @@
       }
     },
     "@flock/wirespec": {
-      "version": "0.8.51",
-      "resolved": "https://registry.npmjs.org/@flock/wirespec/-/wirespec-0.8.51.tgz",
-      "integrity": "sha512-U5OvDN5xYyKBxFttLT51LZNUmuVvRRtfqwqC+4cmDr9p5MwX7tEw2OZQqcynbbJeflFPUsqfts76pFqf9iUaaw==",
+      "version": "0.8.46",
+      "resolved": "https://registry.npmjs.org/@flock/wirespec/-/wirespec-0.8.46.tgz",
+      "integrity": "sha512-mH2wg0W+qoWB0UbD3TlpPaRYOcrf+5oJxi88AdcvdvFnw597nKC5pTvF9lUSH9VrszT976yLxlXQPjGyB4MK8w==",
       "dev": true,
       "requires": {
         "format-util": "^1.0.5"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@babel/preset-react": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
     "@flock-community/flock-eco-webpack": "^2.8.0",
-    "@flock/wirespec": "^0.8.51",
+    "@flock/wirespec": "0.8.46",
     "@fontsource/material-icons": "^5.0.7",
     "@fontsource/roboto": "^5.0.8",
     "@storybook/addon-themes": "^7.5.3",

--- a/src/main/react/clients/ExpenseClient.ts
+++ b/src/main/react/clients/ExpenseClient.ts
@@ -92,7 +92,10 @@ const internalizeCost = (it: ExpenseApi): CostExpense => {
     expenseType: ExpenseType.COST,
     status: internalizeStatus(it.status),
     amount: costDetails.amount,
-    files: costDetails.files,
+    files: costDetails.files.map((it) => ({
+      fileId: it.file.value,
+      name: it.name,
+    })),
   };
 };
 
@@ -117,7 +120,10 @@ const internalizeTravel = (it: ExpenseApi): TravelExpense => {
 const serializeCost = (it: CostExpense): CostExpenseInput => ({
   amount: it.amount,
   description: it.description,
-  files: it.files,
+  files: it.files.map((it) => ({
+    file: { value: it.fileId },
+    name: it.name,
+  })),
   status: it.status,
   personId: { value: it.person.uuid },
   date: it.date.format(ISO_8601_DATE),

--- a/src/main/react/features/expense/ExpenseDialog.tsx
+++ b/src/main/react/features/expense/ExpenseDialog.tsx
@@ -69,6 +69,7 @@ export function ExpenseDialog({
           type === ExpenseType.COST ? ExpenseType.COST : ExpenseType.TRAVEL,
         status: Status.REQUESTED,
         date: it.date,
+        files: it.files,
       }).then((res: CostExpense | TravelExpense) => {
         onComplete?.(res);
       });

--- a/src/main/react/features/expense/ExpenseList.tsx
+++ b/src/main/react/features/expense/ExpenseList.tsx
@@ -95,11 +95,11 @@ export function ExpenseList({ personId, refresh, onClickRow }: DayListProps) {
             {item.files &&
               item.files.map((file) => (
                 <ListItem
-                  key={file.file}
+                  key={file.fileId}
                   button
                   component="a"
                   target="_blank"
-                  href={`/api/expenses/files/${file.file}/${file.name}`}
+                  href={`/api/expenses/files/${file.fileId}/${file.name}`}
                   onClick={(event) => event.stopPropagation()}
                 >
                   <ListItemText primary={file.name} />

--- a/src/main/react/models/Expense.tsx
+++ b/src/main/react/models/Expense.tsx
@@ -15,10 +15,15 @@ export class Expense {
     public person: Person,
     public status: Status,
     public amount: number,
-    public files: any[],
+    public files: ExpenseFile[],
     public expenseType: ExpenseType
   ) {}
 }
+
+export type ExpenseFile = {
+  name: string;
+  fileId: string;
+};
 
 export class CostExpense extends Expense {
   constructor(


### PR DESCRIPTION
FileIds for expenses are wrapped in UUID wrapper types (as of now), on kotlin side.

On typescript side, wirespec assumes there are no wrappers (anymore), this has changed in 0.8.50 or 51.

Note: we really need to have tsconfig or eslint setup to help us spot these issues. We could have prevented this.