### PR TITLE
Hide UpcomingEvents on home page

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -10,6 +10,8 @@ import { CssBaseline, ThemeProvider } from '@material-ui/core';
 import { withThemeFromJSXProvider } from '@storybook/addon-themes';
 import { themeLight } from '../src/main/react/theme/theme-light';
 import { darkTheme } from './themes';
+import { MemoryRouter } from "react-router";
+import React from "react";
 
 /* snipped for brevity */
 
@@ -22,4 +24,11 @@ export const decorators = [
     defaultTheme: 'light',
     Provider: ThemeProvider,
     GlobalStyles: CssBaseline,
-  })];
+  }),
+    (Story) => (
+      <MemoryRouter initialEntries={['/']}>
+        <Story />
+        </MemoryRouter>
+    ),
+
+  ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@testing-library/react": "^9.3.2",
         "@testing-library/user-event": "^14.5.1",
         "@types/jest": "^29.5.10",
+        "@types/react-router": "^5.1.20",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
         "babel-jest": "^24.9.0",
@@ -10210,9 +10211,9 @@
       "dev": true
     },
     "node_modules/@storybook/csf": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.1.tgz",
-      "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.13.tgz",
+      "integrity": "sha512-7xOOwCLGB3ebM87eemep89MYRFTko+D8qE7EdAAq74lgdqRR5cOUtYWJLjO2dLtP94nqoOdHJo6MdLLKzg412Q==",
       "dev": true,
       "dependencies": {
         "type-fest": "^2.19.0"
@@ -11251,6 +11252,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/history": {
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
+      "dev": true
+    },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.4.tgz",
@@ -11444,6 +11451,16 @@
       "integrity": "sha512-V835xgdSVmyQmI1KLV2BEIUgqEuinxp9O4G6g3FqO/SqLac049E53aysv0oEFD2kHfejeKU+ZqL2bcFWj9gLAQ==",
       "dev": true,
       "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-router": {
+      "version": "5.1.20",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
+      "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/history": "^4.7.11",
         "@types/react": "*"
       }
     },
@@ -47243,9 +47260,9 @@
       }
     },
     "@storybook/csf": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.1.tgz",
-      "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.13.tgz",
+      "integrity": "sha512-7xOOwCLGB3ebM87eemep89MYRFTko+D8qE7EdAAq74lgdqRR5cOUtYWJLjO2dLtP94nqoOdHJo6MdLLKzg412Q==",
       "dev": true,
       "requires": {
         "type-fest": "^2.19.0"
@@ -48054,6 +48071,12 @@
         "@types/node": "*"
       }
     },
+    "@types/history": {
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
+      "dev": true
+    },
     "@types/hoist-non-react-statics": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.4.tgz",
@@ -48247,6 +48270,16 @@
       "integrity": "sha512-V835xgdSVmyQmI1KLV2BEIUgqEuinxp9O4G6g3FqO/SqLac049E53aysv0oEFD2kHfejeKU+ZqL2bcFWj9gLAQ==",
       "dev": true,
       "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-router": {
+      "version": "5.1.20",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
+      "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
+      "dev": true,
+      "requires": {
+        "@types/history": "^4.7.11",
         "@types/react": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^14.5.1",
     "@types/jest": "^29.5.10",
+    "@types/react-router": "^5.1.20",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "babel-jest": "^24.9.0",

--- a/src/main/react/features/home/HomeFeature.tsx
+++ b/src/main/react/features/home/HomeFeature.tsx
@@ -22,10 +22,8 @@ import { ExpensesCard } from "../../components/expenses-card/ExpensesCard";
 import { ExpenseClient } from "../../clients/ExpenseClient";
 import { useLoginStatus } from "../../hooks/StatusHook";
 import { Expense } from "../../models/Expense";
-import { UpcomingEventsCard } from "../../components/upcoming-events/UpcomingEventsCard";
 import { EventClient, FlockEvent } from "../../clients/EventClient";
-import { handleEventToggle, isPersonAttending } from "../../utils/EventUtils";
-import { Person } from "../../clients/PersonClient";
+import { subscribeToEvent, unsubscribeFromEvent } from "../../utils/EventUtils";
 
 export function HomeFeature() {
   const [user] = useUserMe();
@@ -83,7 +81,9 @@ export function HomeFeature() {
   };
 
   const eventToggled = (event: FlockEvent, isPresent: boolean) => {
-    handleEventToggle(event, isPresent).then(() => fetchEvents());
+    (isPresent ? subscribeToEvent(event) : unsubscribeFromEvent(event)).then(
+      () => fetchEvents()
+    );
   };
 
   return (
@@ -128,12 +128,13 @@ export function HomeFeature() {
 
           <div className={"gid-auto-fit"}>
             <ExpensesCard items={expenses} />
-            <UpcomingEventsCard
-              items={flockEvents}
-              onEventToggle={(event, isPresent) =>
-                eventToggled(event, isPresent)
-              }
-            />
+            {/* TODO: Enable upcoming events again when feature is finished, er remove completely */}
+            {/*<UpcomingEventsCard*/}
+            {/*  items={flockEvents}*/}
+            {/*  onEventToggle={(event, isPresent) =>*/}
+            {/*     eventToggled(event, isPresent)*/}
+            {/*   }*/}
+            {/* />*/}
           </div>
         </section>
       )}

--- a/src/main/react/utils/EventUtils.tsx
+++ b/src/main/react/utils/EventUtils.tsx
@@ -1,14 +1,13 @@
-import { FlockEvent, EventClient } from "../clients/EventClient";
+import { EventClient, FlockEvent } from "../clients/EventClient";
 
-export const handleEventToggle = (
-  event: FlockEvent,
-  isPresent: boolean
+export const subscribeToEvent = (event: FlockEvent): Promise<FlockEvent> => {
+  return EventClient.subscribeToEvent(event);
+};
+
+export const unsubscribeFromEvent = (
+  event: FlockEvent
 ): Promise<FlockEvent> => {
-  if (isPresent) {
-    return EventClient.subscribeToEvent(event);
-  } else {
-    return EventClient.unsubscribeFromEvent(event);
-  }
+  return EventClient.unsubscribeFromEvent(event);
 };
 
 export const isPersonAttending = (

--- a/src/storybook/components/upcoming-events-card/FlockEventList.stories.tsx
+++ b/src/storybook/components/upcoming-events-card/FlockEventList.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { EventList } from "../../../main/react/components/upcoming-events/EventList";
-import dayjs from "dayjs";
 import { EventType } from "../../../main/react/clients/EventClient";
+import dayjs from "dayjs";
 
 const meta: Meta<typeof EventList> = {
   component: EventList,
@@ -33,7 +33,7 @@ export const withData: Story = {
       {
         description: "Smashing Conference - Freiburg",
         id: 2712,
-        type: EventType.GENERAL_EVENT,
+        type: EventType.CONFERENCE,
         code: "event-code",
         from: dayjs(),
         to: dayjs().add(4, "day"),
@@ -45,7 +45,7 @@ export const withData: Story = {
       {
         description: "FLock Hack Day - Flock HQ.",
         id: 2712,
-        type: EventType.GENERAL_EVENT,
+        type: EventType.FLOCK_HACK_DAY,
         code: "event-code",
         from: dayjs(),
         to: dayjs(),
@@ -57,7 +57,7 @@ export const withData: Story = {
       {
         description: "FLock Hack Day - Flock HQ.",
         id: 2712,
-        type: EventType.GENERAL_EVENT,
+        type: EventType.FLOCK_HACK_DAY,
         code: "event-code",
         from: dayjs(),
         to: dayjs(),
@@ -67,9 +67,9 @@ export const withData: Story = {
         costs: 1200,
       },
       {
-        description: "Random event- Flock HQ.",
+        description: "Community day- Flock HQ.",
         id: 2712,
-        type: EventType.GENERAL_EVENT,
+        type: EventType.FLOCK_COMMUNITY_DAY,
         code: "event-code",
         from: dayjs(),
         to: dayjs(),

--- a/src/storybook/components/upcoming-events-card/FlockEventListItem.stories.tsx
+++ b/src/storybook/components/upcoming-events-card/FlockEventListItem.stories.tsx
@@ -1,14 +1,26 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { EventListItem } from "../../../main/react/components/upcoming-events/EventListItem";
 import dayjs from "dayjs";
+import { EventType } from "../../../main/react/clients/EventClient";
 
 const meta: Meta<typeof EventListItem> = {
   component: EventListItem,
+  parameters: {
+    reactRouter: {
+      routePath: "/users/:userId",
+      routeParams: { userId: "42" },
+      routeHandle: "Profile",
+      searchParams: { tab: "activityLog" },
+      routeState: { fromPage: "homePage" },
+    },
+  },
+
   args: {
-    // @ts-ignore
+    onEventToggle: (x, y) => {},
     event: {
       description: "Super nice event that takes place!",
       id: 2712,
+      type: EventType.GENERAL_EVENT,
       code: "event-code",
       from: dayjs(),
       to: dayjs().add(1, "day"),
@@ -26,10 +38,10 @@ type Story = StoryObj<typeof EventListItem>;
 export const withDateRange: Story = {};
 export const withSingleDate: Story = {
   args: {
-    // @ts-ignore
     event: {
       description: "Super nice event that takes place!",
       id: 2712,
+      type: EventType.GENERAL_EVENT,
       code: "event-code",
       from: dayjs(),
       to: dayjs(),


### PR DESCRIPTION
**Description:**
- Hide the UpcomingEvents section on the home page until further notice.

The expenses are now shown as a 1 column instead
<img width="847" alt="image" src="https://github.com/user-attachments/assets/1c0d35c8-abca-4fff-b6b1-65feadc8dde0" />
