### PR TITLE
use 'stable' ubuntu

### DIFF
--- a/.github/workflows/gcp.yml
+++ b/.github/workflows/gcp.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-deploy:
     name: Build and Deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     # Add "id-token" with the intended permissions.
     permissions:


### PR DESCRIPTION
Fixes a warning from github actions:, 

Example:
https://github.com/flock-community/flock-eco-workday/actions/runs/12695117076
<img width="1083" alt="image" src="https://github.com/user-attachments/assets/63b68530-dee0-46f2-a416-54b8c0605e25" />


https://github.com/actions/runner-images/issues/10636
