### PR TITLE
Update email logic fo Sickdays, Expenses and LeaveDays and improve email styling

### DIFF
--- a/src/main/kotlin/community/flock/eco/workday/controllers/ExpenseController.kt
+++ b/src/main/kotlin/community/flock/eco/workday/controllers/ExpenseController.kt
@@ -188,8 +188,14 @@ class TravelExpenseController(
         expenseService.findById(id)
             ?.applyAuthentication(authentication)
             ?.applyAllowedToUpdate(input.status.consume(), authentication.isAdmin())
-            .run { mapper.consume(input, id) }
-            .run { service.update(id, this) }
+            ?.run {
+                val updatedExpense = mapper.consume(input, id)
+                service.update(
+                    id = id,
+                    input = updatedExpense,
+                    isUpdatedByOwner = authentication.isOwnerOf(this),
+                )
+            }
             ?.produce()
             .toResponse()
 }
@@ -246,8 +252,14 @@ class CostExpenseController(
         expenseService.findById(id)
             ?.applyAuthentication(authentication)
             ?.applyAllowedToUpdate(input.status.consume(), authentication.isAdmin())
-            .run { mapper.consume(input, id) }
-            .run { service.update(id, this) }
+            ?.run {
+                val consume = mapper.consume(input, id)
+                service.update(
+                    id = id,
+                    input = consume,
+                    isUpdatedByOwner = authentication.isOwnerOf(this),
+                )
+            }
             ?.produce()
             .toResponse()
 }

--- a/src/main/kotlin/community/flock/eco/workday/controllers/SickdayController.kt
+++ b/src/main/kotlin/community/flock/eco/workday/controllers/SickdayController.kt
@@ -7,9 +7,8 @@ import community.flock.eco.workday.interfaces.applyAllowedToUpdate
 import community.flock.eco.workday.model.SickDay
 import community.flock.eco.workday.services.PersonService
 import community.flock.eco.workday.services.SickDayService
-import community.flock.eco.workday.services.isUser
 import org.springframework.data.domain.Pageable
-import org.springframework.http.HttpStatus.UNAUTHORIZED
+import org.springframework.http.HttpStatus.FORBIDDEN
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.Authentication
@@ -72,7 +71,13 @@ class SickdayController(
     ) = service.findByCode(code)
         ?.applyAuthentication(authentication)
         ?.applyAllowedToUpdate(form.status, authentication.isAdmin())
-        ?.run { service.update(code, form) }
+        ?.run {
+            service.update(
+                code = code,
+                form = form,
+                isUpdatedByOwner = authentication.isOwnerOf(this),
+            )
+        }
         .toResponse()
 
     @DeleteMapping("/{code}")
@@ -93,18 +98,20 @@ class SickdayController(
             ?.let {
                 this.copy(personId = it.uuid)
             }
-            ?: throw ResponseStatusException(UNAUTHORIZED, "User is not linked to person")
+            ?: throw ResponseStatusException(FORBIDDEN, "User is not linked to person")
     }
+
+    private fun SickDay.applyAuthentication(authentication: Authentication) =
+        apply {
+            if (!(authentication.isAdmin() || authentication.isOwnerOf(this))) {
+                throw ResponseStatusException(FORBIDDEN, "User has no access to object")
+            }
+        }
 
     private fun Authentication.isAdmin(): Boolean =
         this.authorities
             .map { it.authority }
             .contains(SickdayAuthority.ADMIN.toName())
 
-    private fun SickDay.applyAuthentication(authentication: Authentication) =
-        apply {
-            if (!(authentication.isAdmin() || this.person.isUser(authentication.name))) {
-                throw ResponseStatusException(UNAUTHORIZED, "User has not access to object")
-            }
-        }
+    private fun Authentication.isOwnerOf(sickDay: SickDay) = isAssociatedWith(sickDay.person)
 }

--- a/src/main/kotlin/community/flock/eco/workday/services/ExpenseService.kt
+++ b/src/main/kotlin/community/flock/eco/workday/services/ExpenseService.kt
@@ -76,12 +76,17 @@ class CostExpenseService(
     fun update(
         id: UUID,
         input: CostExpense,
+        isUpdatedByOwner: Boolean,
     ): CostExpense? {
         val currentExpense = costExpenseRepository.findById(id).toNullable()
         return currentExpense
             ?.let { costExpenseRepository.save(input) }
             ?.also { applicationEventPublisher.publishEvent(UpdateExpenseEvent(it)) }
-            ?.also { costExpenseMailService.sendUpdate(it) }
+            ?.also {
+                if (!isUpdatedByOwner) {
+                    costExpenseMailService.sendUpdate(it)
+                }
+            }
     }
 }
 
@@ -102,11 +107,16 @@ class TravelExpenseService(
     fun update(
         id: UUID,
         input: TravelExpense,
+        isUpdatedByOwner: Boolean,
     ): TravelExpense? {
         val currentExpense = travelExpenseRepository.findById(id).toNullable()
         return currentExpense
             ?.let { travelExpenseRepository.save(input) }
             ?.also { applicationEventPublisher.publishEvent(UpdateExpenseEvent(it)) }
-            ?.also { travelExpenseMailService.sendUpdate(it) }
+            ?.also {
+                if (!isUpdatedByOwner) {
+                    travelExpenseMailService.sendUpdate(it)
+                }
+            }
     }
 }

--- a/src/main/kotlin/community/flock/eco/workday/services/ExpenseService.kt
+++ b/src/main/kotlin/community/flock/eco/workday/services/ExpenseService.kt
@@ -81,7 +81,7 @@ class CostExpenseService(
         return currentExpense
             ?.let { costExpenseRepository.save(input) }
             ?.also { applicationEventPublisher.publishEvent(UpdateExpenseEvent(it)) }
-            ?.also { costExpenseMailService.sendUpdate(currentExpense, it) }
+            ?.also { costExpenseMailService.sendUpdate(it) }
     }
 }
 
@@ -107,6 +107,6 @@ class TravelExpenseService(
         return currentExpense
             ?.let { travelExpenseRepository.save(input) }
             ?.also { applicationEventPublisher.publishEvent(UpdateExpenseEvent(it)) }
-            ?.also { travelExpenseMailService.sendUpdate(currentExpense, it) }
+            ?.also { travelExpenseMailService.sendUpdate(it) }
     }
 }

--- a/src/main/kotlin/community/flock/eco/workday/services/LeaveDayService.kt
+++ b/src/main/kotlin/community/flock/eco/workday/services/LeaveDayService.kt
@@ -91,6 +91,7 @@ class LeaveDayService(
     fun update(
         code: String,
         form: LeaveDayForm,
+        isUpdatedByOwner: Boolean,
     ): LeaveDay {
         val currentLeaveDay = leaveDayRepository.findByCode(code).toNullable()
         return currentLeaveDay
@@ -101,7 +102,9 @@ class LeaveDayService(
                     .save()
             }
             .also {
-                emailService.sendUpdate(it)
+                if (!isUpdatedByOwner) {
+                    emailService.sendUpdate(it)
+                }
             }
     }
 

--- a/src/main/kotlin/community/flock/eco/workday/services/LeaveDayService.kt
+++ b/src/main/kotlin/community/flock/eco/workday/services/LeaveDayService.kt
@@ -8,7 +8,7 @@ import community.flock.eco.workday.interfaces.validate
 import community.flock.eco.workday.model.LeaveDay
 import community.flock.eco.workday.model.Status
 import community.flock.eco.workday.repository.LeaveDayRepository
-import community.flock.eco.workday.services.email.LeaveDayEmailService
+import community.flock.eco.workday.services.email.LeaveDayMailService
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -21,7 +21,7 @@ class LeaveDayService(
     private val leaveDayRepository: LeaveDayRepository,
     private val personService: PersonService,
     private val entityManager: EntityManager,
-    private val emailService: LeaveDayEmailService,
+    private val emailService: LeaveDayMailService,
 ) {
     fun findByCode(code: String) = leaveDayRepository.findByCode(code).toNullable()
 
@@ -101,7 +101,7 @@ class LeaveDayService(
                     .save()
             }
             .also {
-                emailService.sendUpdate(currentLeaveDay!!, it)
+                emailService.sendUpdate(it)
             }
     }
 

--- a/src/main/kotlin/community/flock/eco/workday/services/SickDayService.kt
+++ b/src/main/kotlin/community/flock/eco/workday/services/SickDayService.kt
@@ -92,6 +92,7 @@ class SickDayService(
     fun update(
         code: String,
         form: SickDayForm,
+        isUpdatedByOwner: Boolean,
     ): SickDay {
         val currentSickDay = repository.findByCode(code).toNullable()
         return currentSickDay
@@ -101,7 +102,11 @@ class SickDayService(
                     .consume(this)
                     .save()
             }
-            .also { emailService.sendUpdate(it) }
+            .also {
+                if (!isUpdatedByOwner) {
+                    emailService.sendUpdate(it)
+                }
+            }
     }
 
     @Transactional

--- a/src/main/kotlin/community/flock/eco/workday/services/SickDayService.kt
+++ b/src/main/kotlin/community/flock/eco/workday/services/SickDayService.kt
@@ -6,7 +6,7 @@ import community.flock.eco.workday.interfaces.validate
 import community.flock.eco.workday.model.SickDay
 import community.flock.eco.workday.model.Status
 import community.flock.eco.workday.repository.SickdayRepository
-import community.flock.eco.workday.services.email.SickDayEmailService
+import community.flock.eco.workday.services.email.SickDayMailService
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -19,7 +19,7 @@ class SickDayService(
     private val repository: SickdayRepository,
     private val personService: PersonService,
     private val entityManager: EntityManager,
-    private val emailService: SickDayEmailService,
+    private val emailService: SickDayMailService,
 ) {
     fun findAll(pageable: Pageable) =
         repository
@@ -101,7 +101,7 @@ class SickDayService(
                     .consume(this)
                     .save()
             }
-            .also { emailService.sendUpdate(currentSickDay!!, it) }
+            .also { emailService.sendUpdate(it) }
     }
 
     @Transactional

--- a/src/main/kotlin/community/flock/eco/workday/services/WorkDayService.kt
+++ b/src/main/kotlin/community/flock/eco/workday/services/WorkDayService.kt
@@ -99,7 +99,7 @@ class WorkDayService(
     fun update(
         workDayCode: String,
         form: WorkDayForm,
-        isOwnWorkDay: Boolean,
+        isUpdatedByOwner: Boolean,
     ): WorkDay {
         val currentWorkday = workDayRepository.findByCode(workDayCode).toNullable()
         return currentWorkday
@@ -110,7 +110,7 @@ class WorkDayService(
                     .save()
             }
             .also {
-                if (!isOwnWorkDay) {
+                if (!isUpdatedByOwner) {
                     emailService.sendUpdate(it)
                 }
             }

--- a/src/main/kotlin/community/flock/eco/workday/services/email/CostExpenseMailService.kt
+++ b/src/main/kotlin/community/flock/eco/workday/services/email/CostExpenseMailService.kt
@@ -10,13 +10,11 @@ import org.springframework.stereotype.Service
 @Service
 class CostExpenseMailService(
     private val emailService: EmailService,
-    private val mailjetTemplateProperties: MailjetTemplateProperties
+    private val mailjetTemplateProperties: MailjetTemplateProperties,
 ) {
     private val log: Logger = LoggerFactory.getLogger(CostExpenseMailService::class.java)
 
-    fun sendUpdate(
-        expense: CostExpense,
-    ) {
+    fun sendUpdate(expense: CostExpense) {
         val recipient = expense.person
 
         val subject = "Declaratie update - ${expense.description ?: "beschrijving onbekend"}!"

--- a/src/main/kotlin/community/flock/eco/workday/services/email/CostExpenseMailService.kt
+++ b/src/main/kotlin/community/flock/eco/workday/services/email/CostExpenseMailService.kt
@@ -17,18 +17,13 @@ class CostExpenseMailService(
     fun sendUpdate(expense: CostExpense) {
         val recipient = expense.person
 
-        val subject = "Declaratie update - ${expense.description ?: "beschrijving onbekend"}!"
+        val subject = "Cost expense update: ${expense.description ?: "description unknown"}"
         val emailMessage =
             """
-            <p>Je declaratie voor '${expense.description ?: "onbekend"}' is bijgewerkt.<p>
+            |<p>Your cost expense for '${expense.description ?: "unknown"}' has been updated.<p>
+            |${expense.html()}
+            """.trimMargin()
 
-            <ul>
-                <li>Beschrijving: ${expense.description}</li>
-                <li>Kosten gemaakt op: ${expense.date.toHumanReadable()}</li>
-                <li>Bedrag: ${expense.amount}</li>
-                <li>Status: ${expense.status}</li>
-            </ul>
-            """.trimIndent()
         log.info("Email generated for CostExpense update for ${recipient.email}")
 
         val templateVariables = emailService.createTemplateVariables(recipient.firstname, emailMessage)
@@ -44,8 +39,13 @@ class CostExpenseMailService(
     fun sendNotification(expense: CostExpense) {
         val employee = expense.person
 
-        val subject = "Update in CostExpense."
-        val emailMessage = "Er is een CostExpense door ${employee.firstname} toegevoegd."
+        val subject = "Cost expense update for ${employee.firstname}"
+        val emailMessage =
+            """
+            |<p>A cost expense has been added for ${employee.firstname}.</p>
+            |${expense.html()}
+            """.trimMargin()
+
         val templateVariables = emailService.createTemplateVariables(employee.firstname, emailMessage)
 
         log.info("Email generated for CostExpense notification for ${employee.email}")
@@ -56,4 +56,18 @@ class CostExpenseMailService(
             mailjetTemplateProperties.notificationTemplateId,
         )
     }
+
+    private fun CostExpense.html() =
+        // language=html
+        """
+        |<div>
+        |    <p>Cost expense state:</p>
+        |    <ul>
+        |        <li>Description: $description</li>
+        |        <li>Incurred on: ${date.toHumanReadable()}</li>
+        |        <li>Amount: €$amount</li>
+        |        <li>Status: $status</li>
+        |    </ul>
+        |</div>
+        """.trimMargin()
 }

--- a/src/main/kotlin/community/flock/eco/workday/services/email/LeaveDayMailService.kt
+++ b/src/main/kotlin/community/flock/eco/workday/services/email/LeaveDayMailService.kt
@@ -6,7 +6,6 @@ import community.flock.eco.workday.utils.DateUtils.toHumanReadable
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import java.time.format.DateTimeFormatter
 
 @Service
 class LeaveDayMailService(
@@ -18,20 +17,12 @@ class LeaveDayMailService(
     fun sendUpdate(leaveDay: LeaveDay) {
         val recipient = leaveDay.person
 
-        val subject = "Leave Day update - ${leaveDay.description}"
+        val subject = "Leave day update: ${leaveDay.from.toHumanReadable()} to ${leaveDay.to.toHumanReadable()} - ${leaveDay.description}"
         val emailMessage =
             """
-            <p>Je verlof voor '${leaveDay.description}' is bijgewerkt.<p>
-
-            <ul>
-                <li>Omschrijving: ${leaveDay.description}</li>
-                <li>Type: ${leaveDay.type}</li>
-                <li>Van: ${leaveDay.from.toHumanReadable()}</li>
-                <li>Tot en met: ${leaveDay.to.toHumanReadable()}</li>
-                <li>Totaal aantal verlofuren: ${leaveDay.hours}</li>
-                <li>Status: ${leaveDay.status}</li>
-            </ul>
-            """.trimIndent()
+            |<p>Your leave day from ${leaveDay.from.toHumanReadable()} to ${leaveDay.to.toHumanReadable()} has been updated.</p>
+            |${leaveDay.html()}
+            """.trimMargin()
 
         log.info("Email generated for LeaveDay update for ${recipient.email}")
 
@@ -46,13 +37,15 @@ class LeaveDayMailService(
     }
 
     fun sendNotification(leaveDay: LeaveDay) {
-        val timeDateFormat = DateTimeFormatter.ofPattern("dd/MM/yyyy")
         val employee = leaveDay.person
 
-        val subject = "Update in Leave Day."
+        val subject = "Leave day update for ${employee.firstname}"
         val emailMessage =
-            "Er is een update van ${employee.firstname} in de Leave Day aanvraag" +
-                " (van: ${leaveDay.from.format(timeDateFormat)} tot: ${leaveDay.to.format(timeDateFormat)})."
+            """
+                |<p>A leave day has been added for ${employee.firstname}.</p>
+                |${leaveDay.html()}
+            """.trimMargin()
+
         val templateVariables = emailService.createTemplateVariables(employee.firstname, emailMessage)
 
         log.info("Email generated for LeaveDay notification for ${employee.email}")
@@ -63,4 +56,20 @@ class LeaveDayMailService(
             mailjetTemplateProperties.notificationTemplateId,
         )
     }
+
+    private fun LeaveDay.html() =
+        // language=html
+        """
+        |<div>
+        |    <p>Leave day state:</p>
+        |    <ul>
+        |        <li>Description: $description</li>
+        |        <li>Type: $type</li>
+        |        <li>From: ${from.toHumanReadable()}</li>
+        |        <li>Up to and including: ${to.toHumanReadable()}</li>
+        |        <li>Total leave hours: $hours</li>
+        |        <li>Status: $status</li>
+        |    </ul>
+        |</div>
+        """.trimMargin()
 }

--- a/src/main/kotlin/community/flock/eco/workday/services/email/LeaveDayMailService.kt
+++ b/src/main/kotlin/community/flock/eco/workday/services/email/LeaveDayMailService.kt
@@ -11,7 +11,7 @@ import java.time.format.DateTimeFormatter
 @Service
 class LeaveDayMailService(
     private val emailService: EmailService,
-    private val mailjetTemplateProperties: MailjetTemplateProperties
+    private val mailjetTemplateProperties: MailjetTemplateProperties,
 ) {
     private val log: Logger = LoggerFactory.getLogger(LeaveDayMailService::class.java)
 

--- a/src/main/kotlin/community/flock/eco/workday/services/email/SickDayMailService.kt
+++ b/src/main/kotlin/community/flock/eco/workday/services/email/SickDayMailService.kt
@@ -2,40 +2,46 @@ package community.flock.eco.workday.services.email
 
 import community.flock.eco.workday.config.properties.MailjetTemplateProperties
 import community.flock.eco.workday.model.SickDay
+import community.flock.eco.workday.utils.DateUtils.toHumanReadable
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.format.DateTimeFormatter
 
 @Service
-class SickDayEmailService(private val emailService: EmailService, private val mailjetTemplateProperties: MailjetTemplateProperties) {
-    private val log: Logger = LoggerFactory.getLogger(SickDayEmailService::class.java)
+class SickDayMailService(
+    private val emailService: EmailService, private val mailjetTemplateProperties: MailjetTemplateProperties
+) {
+    private val log: Logger = LoggerFactory.getLogger(SickDayMailService::class.java)
 
     fun sendUpdate(
-        old: SickDay,
-        new: SickDay,
+        sickDay: SickDay,
     ) {
-        val recipient = new.person
+        val recipient = sickDay.person
 
-        var subject = "Update in SickDay."
-        var emailMessage = "Er is een update in SickDay."
+        val subject = "SickDay update - ${sickDay.description ?: "ziek"}"
+        val emailMessage =
+            """
+            <p>Je ziekteverzuim voor '${sickDay.description ?: "geen omschrijving"}' is bijgewerkt.<p>
 
-        if (old.status !== new.status) {
-            subject = "Status update in SickDay!"
-            emailMessage = "De status van je SickDay is veranderd.\n\n" +
-                "Vorige status: ${old.status}.\n" +
-                "Nieuwe status: ${new.status}."
-        }
+            <ul>
+                <li>Omschrijving: ${sickDay.description}</li>
+                <li>Van: ${sickDay.from.toHumanReadable()}</li>
+                <li>Tot en met: ${sickDay.to.toHumanReadable()}</li>
+                <li>Total aantal verzuimuren: ${sickDay.hours}</li>
+                <li>Status: ${sickDay.status}</li>
+            </ul>
+            """.trimIndent()
 
         log.info("Email generated for SickDay update for ${recipient.email}")
 
         val templateVariables = emailService.createTemplateVariables(recipient.firstname, emailMessage)
         emailService.sendEmailMessage(
-            recipient.receiveEmail,
-            recipient.email,
-            subject,
-            templateVariables,
-            mailjetTemplateProperties.updateTemplateId,
+            personReceiveEmail = recipient.receiveEmail,
+            recipientEmail = recipient.email,
+            emailSubject = subject,
+            templateVariables = templateVariables,
+            templateId = mailjetTemplateProperties.updateTemplateId,
         )
     }
 

--- a/src/main/kotlin/community/flock/eco/workday/services/email/SickDayMailService.kt
+++ b/src/main/kotlin/community/flock/eco/workday/services/email/SickDayMailService.kt
@@ -10,13 +10,12 @@ import java.time.format.DateTimeFormatter
 
 @Service
 class SickDayMailService(
-    private val emailService: EmailService, private val mailjetTemplateProperties: MailjetTemplateProperties
+    private val emailService: EmailService,
+    private val mailjetTemplateProperties: MailjetTemplateProperties,
 ) {
     private val log: Logger = LoggerFactory.getLogger(SickDayMailService::class.java)
 
-    fun sendUpdate(
-        sickDay: SickDay,
-    ) {
+    fun sendUpdate(sickDay: SickDay) {
         val recipient = sickDay.person
 
         val subject = "SickDay update - ${sickDay.description ?: "ziek"}"

--- a/src/main/kotlin/community/flock/eco/workday/services/email/TravelExpenseMailService.kt
+++ b/src/main/kotlin/community/flock/eco/workday/services/email/TravelExpenseMailService.kt
@@ -10,13 +10,11 @@ import org.springframework.stereotype.Service
 @Service
 class TravelExpenseMailService(
     private val emailService: EmailService,
-    private val mailjetTemplateProperties: MailjetTemplateProperties
+    private val mailjetTemplateProperties: MailjetTemplateProperties,
 ) {
     private val log: Logger = LoggerFactory.getLogger(TravelExpenseMailService::class.java)
 
-    fun sendUpdate(
-        expense: TravelExpense,
-    ) {
+    fun sendUpdate(expense: TravelExpense) {
         val recipient = expense.person
 
         val subject = "Reiskostenvergoeding update - ${expense.description ?: "beschrijving onbekend"}!"

--- a/src/main/kotlin/community/flock/eco/workday/services/email/TravelExpenseMailService.kt
+++ b/src/main/kotlin/community/flock/eco/workday/services/email/TravelExpenseMailService.kt
@@ -17,19 +17,12 @@ class TravelExpenseMailService(
     fun sendUpdate(expense: TravelExpense) {
         val recipient = expense.person
 
-        val subject = "Reiskostenvergoeding update - ${expense.description ?: "beschrijving onbekend"}!"
+        val subject = "Travel expense update: ${expense.description ?: "description unknown"}"
         val emailMessage =
             """
-            <p>Je reiskostenvergoeding voor '${expense.description ?: "onbekend"}' is bijgewerkt.<p>
-
-            <ul>
-                <li>Beschrijving: ${expense.description}</li>
-                <li>Datum van uitgifte: ${expense.date.toHumanReadable()}</li>
-                <li>Afstand: ${expense.distance}</li>
-                <li>Kilometervergoeding: ${expense.allowance}</li>
-                <li>Status: ${expense.status}</li>
-            </ul>
-            """.trimIndent()
+            |<p>Your travel expense for '${expense.description ?: "unknown"}' has been updated.<p>
+            |${expense.html()}
+            """.trimMargin()
 
         log.info("Email generated for TravelExpense update for ${recipient.email}")
 
@@ -46,8 +39,12 @@ class TravelExpenseMailService(
     fun sendNotification(expense: TravelExpense) {
         val employee = expense.person
 
-        val subject = "Update in TravelExpense."
-        val emailMessage = "Er is een TravelExpense door ${employee.firstname} toegevoegd."
+        val subject = "Travel expense update for ${employee.firstname}"
+        val emailMessage =
+            """
+            |<p>A travel expense has been added for ${employee.firstname}.</p>
+            |${expense.html()}
+            """.trimMargin()
         val templateVariables = emailService.createTemplateVariables(employee.firstname, emailMessage)
 
         log.info("Email generated for TravelExpense notification for ${employee.email}")
@@ -58,4 +55,19 @@ class TravelExpenseMailService(
             mailjetTemplateProperties.notificationTemplateId,
         )
     }
+
+    private fun TravelExpense.html() =
+        // language=html
+        """
+        |<div>
+        |    <p>Travel expense state:</p>
+        |    <ul>
+        |        <li>Description: $description</li>
+        |        <li>Issue date: ${date.toHumanReadable()}</li>
+        |        <li>Distance: $distance</li>
+        |        <li>Allowance: $allowance</li>
+        |        <li>Status: $status</li>
+        |    </ul>
+        |</div>
+        """.trimMargin()
 }

--- a/src/main/kotlin/community/flock/eco/workday/services/email/WorkdayEmailService.kt
+++ b/src/main/kotlin/community/flock/eco/workday/services/email/WorkdayEmailService.kt
@@ -35,11 +35,11 @@ class WorkdayEmailService(
         val templateVariables =
             emailService.createTemplateVariables(recipient.firstname, emailMessage)
         emailService.sendEmailMessage(
-            recipient.receiveEmail,
-            recipient.email,
-            subject,
-            templateVariables,
-            mailjetTemplateProperties.updateTemplateId,
+            personReceiveEmail = recipient.receiveEmail,
+            recipientEmail = recipient.email,
+            emailSubject = subject,
+            templateVariables = templateVariables,
+            templateId = mailjetTemplateProperties.updateTemplateId,
         )
     }
 
@@ -88,6 +88,7 @@ class WorkdayEmailService(
     }
 
     private fun WorkDay.html() =
+        // language=html
         """
         |<div>
         |    <p>Workday state</p>

--- a/src/main/kotlin/community/flock/eco/workday/utils/DateUtils.kt
+++ b/src/main/kotlin/community/flock/eco/workday/utils/DateUtils.kt
@@ -47,7 +47,7 @@ object DateUtils {
         return countWorkDaysInPeriod(from, to)
     }
 
-    val humanReadableDateFormat = DateTimeFormatter.ofPattern("dd-MM-yyyy")
+    val humanReadableDateFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("dd-MM-yyyy")
 
-    fun LocalDate.toHumanReadable() = format(humanReadableDateFormat)
+    fun LocalDate.toHumanReadable(): String = format(humanReadableDateFormat)
 }

--- a/src/test/kotlin/community/flock/eco/workday/services/WorkDayServiceIntegrationTest.kt
+++ b/src/test/kotlin/community/flock/eco/workday/services/WorkDayServiceIntegrationTest.kt
@@ -62,7 +62,7 @@ class WorkDayServiceIntegrationTest(
             workDayService.update(
                 workDayCode = created.code,
                 form = updateForm,
-                isOwnWorkDay = false,
+                isUpdatedByOwner = false,
             )
         assertNotNull(updated.id)
         assertEquals(25.0, updated.hours)

--- a/src/test/kotlin/community/flock/eco/workday/services/email/CostExpenseMailServiceTest.kt
+++ b/src/test/kotlin/community/flock/eco/workday/services/email/CostExpenseMailServiceTest.kt
@@ -66,4 +66,3 @@ class CostExpenseMailServiceTest {
         }
     }
 }
-

--- a/src/test/kotlin/community/flock/eco/workday/services/email/CostExpenseMailServiceTest.kt
+++ b/src/test/kotlin/community/flock/eco/workday/services/email/CostExpenseMailServiceTest.kt
@@ -1,0 +1,69 @@
+package community.flock.eco.workday.services.email
+
+import community.flock.eco.workday.config.properties.MailjetTemplateProperties
+import community.flock.eco.workday.model.CostExpense
+import community.flock.eco.workday.model.Status
+import community.flock.eco.workday.model.aPerson
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.json.JSONObject
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.util.UUID
+
+class CostExpenseMailServiceTest {
+    private val emailService: EmailService = mockk(relaxed = true)
+    private val mailjetTemplateProperties: MailjetTemplateProperties = mockk()
+
+    private val service = CostExpenseMailService(emailService, mailjetTemplateProperties)
+
+    @Test
+    fun `Send email`() {
+        val costExpense =
+            CostExpense(
+                id = UUID.randomUUID(),
+                date = LocalDate.of(2025, 2, 13),
+                description = "Aankoop ergonomische hagelslag",
+                person = aPerson(),
+                status = Status.REQUESTED,
+                amount = 43.21,
+                files = emptyList(),
+            )
+
+        val expectedEmailMessage =
+            """
+            <p>Je declaratie voor 'Aankoop ergonomische hagelslag' is bijgewerkt.<p>
+
+            <ul>
+                <li>Beschrijving: Aankoop ergonomische hagelslag</li>
+                <li>Kosten gemaakt op: 13-02-2025</li>
+                <li>Bedrag: 43.21</li>
+                <li>Status: REQUESTED</li>
+            </ul>
+            """.trimIndent()
+        val templateVariables = JSONObject()
+        every {
+            emailService.createTemplateVariables(
+                costExpense.person.firstname,
+                expectedEmailMessage,
+            )
+        }.returns(templateVariables)
+
+        val templateId = 3
+        every { mailjetTemplateProperties.updateTemplateId }.returns(templateId)
+
+        service.sendUpdate(costExpense)
+
+        verify {
+            emailService.sendEmailMessage(
+                costExpense.person.receiveEmail,
+                costExpense.person.email,
+                "Declaratie update - Aankoop ergonomische hagelslag!",
+                templateVariables,
+                templateId,
+            )
+        }
+    }
+}
+

--- a/src/test/kotlin/community/flock/eco/workday/services/email/CostExpenseMailServiceTest.kt
+++ b/src/test/kotlin/community/flock/eco/workday/services/email/CostExpenseMailServiceTest.kt
@@ -33,14 +33,16 @@ class CostExpenseMailServiceTest {
 
         val expectedEmailMessage =
             """
-            <p>Je declaratie voor 'Aankoop ergonomische hagelslag' is bijgewerkt.<p>
-
-            <ul>
-                <li>Beschrijving: Aankoop ergonomische hagelslag</li>
-                <li>Kosten gemaakt op: 13-02-2025</li>
-                <li>Bedrag: 43.21</li>
-                <li>Status: REQUESTED</li>
-            </ul>
+            <p>Your cost expense for 'Aankoop ergonomische hagelslag' has been updated.<p>
+            <div>
+                <p>Cost expense state:</p>
+                <ul>
+                    <li>Description: Aankoop ergonomische hagelslag</li>
+                    <li>Incurred on: 13-02-2025</li>
+                    <li>Amount: €43.21</li>
+                    <li>Status: REQUESTED</li>
+                </ul>
+            </div>
             """.trimIndent()
         val templateVariables = JSONObject()
         every {
@@ -59,7 +61,7 @@ class CostExpenseMailServiceTest {
             emailService.sendEmailMessage(
                 costExpense.person.receiveEmail,
                 costExpense.person.email,
-                "Declaratie update - Aankoop ergonomische hagelslag!",
+                "Cost expense update: Aankoop ergonomische hagelslag",
                 templateVariables,
                 templateId,
             )

--- a/src/test/kotlin/community/flock/eco/workday/services/email/LeaveDayMailServiceTest.kt
+++ b/src/test/kotlin/community/flock/eco/workday/services/email/LeaveDayMailServiceTest.kt
@@ -28,8 +28,8 @@ class LeaveDayMailServiceTest {
                 person = aPerson(),
                 status = Status.REQUESTED,
                 code = UUID.randomUUID().toString(),
-                from = LocalDate.of(2028,9,12),
-                to = LocalDate.of(2028,10,2),
+                from = LocalDate.of(2028, 9, 12),
+                to = LocalDate.of(2028, 10, 2),
                 hours = 66.6,
                 days = emptyList(),
                 type = LeaveDayType.UNPAID_PARENTAL_LEAVE,
@@ -72,4 +72,3 @@ class LeaveDayMailServiceTest {
         }
     }
 }
-

--- a/src/test/kotlin/community/flock/eco/workday/services/email/LeaveDayMailServiceTest.kt
+++ b/src/test/kotlin/community/flock/eco/workday/services/email/LeaveDayMailServiceTest.kt
@@ -1,0 +1,75 @@
+package community.flock.eco.workday.services.email
+
+import community.flock.eco.workday.config.properties.MailjetTemplateProperties
+import community.flock.eco.workday.model.LeaveDay
+import community.flock.eco.workday.model.LeaveDayType
+import community.flock.eco.workday.model.Status
+import community.flock.eco.workday.model.aPerson
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.json.JSONObject
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.util.UUID
+
+class LeaveDayMailServiceTest {
+    private val emailService: EmailService = mockk(relaxed = true)
+    private val mailjetTemplateProperties: MailjetTemplateProperties = mockk()
+
+    private val service = LeaveDayMailService(emailService, mailjetTemplateProperties)
+
+    @Test
+    fun `Send email`() {
+        val leaveDay =
+            LeaveDay(
+                id = 42L,
+                description = "Papadagen voor de win",
+                person = aPerson(),
+                status = Status.REQUESTED,
+                code = UUID.randomUUID().toString(),
+                from = LocalDate.of(2028,9,12),
+                to = LocalDate.of(2028,10,2),
+                hours = 66.6,
+                days = emptyList(),
+                type = LeaveDayType.UNPAID_PARENTAL_LEAVE,
+            )
+
+        val expectedEmailMessage =
+            """
+            <p>Je verlof voor 'Papadagen voor de win' is bijgewerkt.<p>
+
+            <ul>
+                <li>Omschrijving: Papadagen voor de win</li>
+                <li>Type: UNPAID_PARENTAL_LEAVE</li>
+                <li>Van: 12-09-2028</li>
+                <li>Tot en met: 02-10-2028</li>
+                <li>Totaal aantal verlofuren: 66.6</li>
+                <li>Status: REQUESTED</li>
+            </ul>
+            """.trimIndent()
+        val templateVariables = JSONObject()
+        every {
+            emailService.createTemplateVariables(
+                leaveDay.person.firstname,
+                expectedEmailMessage,
+            )
+        }.returns(templateVariables)
+
+        val templateId = 3
+        every { mailjetTemplateProperties.updateTemplateId }.returns(templateId)
+
+        service.sendUpdate(leaveDay)
+
+        verify {
+            emailService.sendEmailMessage(
+                leaveDay.person.receiveEmail,
+                leaveDay.person.email,
+                "Leave Day update - Papadagen voor de win",
+                templateVariables,
+                templateId,
+            )
+        }
+    }
+}
+

--- a/src/test/kotlin/community/flock/eco/workday/services/email/LeaveDayMailServiceTest.kt
+++ b/src/test/kotlin/community/flock/eco/workday/services/email/LeaveDayMailServiceTest.kt
@@ -37,16 +37,18 @@ class LeaveDayMailServiceTest {
 
         val expectedEmailMessage =
             """
-            <p>Je verlof voor 'Papadagen voor de win' is bijgewerkt.<p>
-
-            <ul>
-                <li>Omschrijving: Papadagen voor de win</li>
-                <li>Type: UNPAID_PARENTAL_LEAVE</li>
-                <li>Van: 12-09-2028</li>
-                <li>Tot en met: 02-10-2028</li>
-                <li>Totaal aantal verlofuren: 66.6</li>
-                <li>Status: REQUESTED</li>
-            </ul>
+            <p>Your leave day from 12-09-2028 to 02-10-2028 has been updated.</p>
+            <div>
+                <p>Leave day state:</p>
+                <ul>
+                    <li>Description: Papadagen voor de win</li>
+                    <li>Type: UNPAID_PARENTAL_LEAVE</li>
+                    <li>From: 12-09-2028</li>
+                    <li>Up to and including: 02-10-2028</li>
+                    <li>Total leave hours: 66.6</li>
+                    <li>Status: REQUESTED</li>
+                </ul>
+            </div>
             """.trimIndent()
         val templateVariables = JSONObject()
         every {
@@ -65,7 +67,7 @@ class LeaveDayMailServiceTest {
             emailService.sendEmailMessage(
                 leaveDay.person.receiveEmail,
                 leaveDay.person.email,
-                "Leave Day update - Papadagen voor de win",
+                "Leave day update: 12-09-2028 to 02-10-2028 - Papadagen voor de win",
                 templateVariables,
                 templateId,
             )

--- a/src/test/kotlin/community/flock/eco/workday/services/email/SickDayMailServiceTest.kt
+++ b/src/test/kotlin/community/flock/eco/workday/services/email/SickDayMailServiceTest.kt
@@ -35,15 +35,15 @@ class SickDayMailServiceTest {
 
         val expectedEmailMessage =
             """
-           <p>Je ziekteverzuim voor 'Ziek, zwak en misselijk' is bijgewerkt.<p>
+            <p>Je ziekteverzuim voor 'Ziek, zwak en misselijk' is bijgewerkt.<p>
 
-           <ul>
-               <li>Omschrijving: Ziek, zwak en misselijk</li>
-               <li>Van: 13-02-2025</li>
-               <li>Tot en met: 13-02-2025</li>
-               <li>Total aantal verzuimuren: 12.0</li>
-               <li>Status: REQUESTED</li>
-           </ul>
+            <ul>
+                <li>Omschrijving: Ziek, zwak en misselijk</li>
+                <li>Van: 13-02-2025</li>
+                <li>Tot en met: 13-02-2025</li>
+                <li>Total aantal verzuimuren: 12.0</li>
+                <li>Status: REQUESTED</li>
+            </ul>
             """.trimIndent()
 
         val templateVariables = JSONObject()

--- a/src/test/kotlin/community/flock/eco/workday/services/email/SickDayMailServiceTest.kt
+++ b/src/test/kotlin/community/flock/eco/workday/services/email/SickDayMailServiceTest.kt
@@ -1,0 +1,72 @@
+package community.flock.eco.workday.services.email
+
+import community.flock.eco.workday.config.properties.MailjetTemplateProperties
+import community.flock.eco.workday.model.SickDay
+import community.flock.eco.workday.model.Status
+import community.flock.eco.workday.model.aPerson
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.json.JSONObject
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.util.UUID
+
+class SickDayMailServiceTest {
+    private val emailService: EmailService = mockk(relaxed = true)
+    private val mailjetTemplateProperties: MailjetTemplateProperties = mockk()
+
+    private val service = SickDayMailService(emailService, mailjetTemplateProperties)
+
+    @Test
+    fun `Send email`() {
+        val sickDay =
+            SickDay(
+                id = 42L,
+                description = "Ziek, zwak en misselijk",
+                person = aPerson(),
+                status = Status.REQUESTED,
+                code = UUID.randomUUID().toString(),
+                from = LocalDate.of(2025, 2, 13),
+                to = LocalDate.of(2025, 2, 13),
+                hours = 12.0,
+                days = emptyList(),
+            )
+
+        val expectedEmailMessage =
+            """
+           <p>Je ziekteverzuim voor 'Ziek, zwak en misselijk' is bijgewerkt.<p>
+
+           <ul>
+               <li>Omschrijving: Ziek, zwak en misselijk</li>
+               <li>Van: 13-02-2025</li>
+               <li>Tot en met: 13-02-2025</li>
+               <li>Total aantal verzuimuren: 12.0</li>
+               <li>Status: REQUESTED</li>
+           </ul>
+            """.trimIndent()
+
+        val templateVariables = JSONObject()
+        every {
+            emailService.createTemplateVariables(
+                sickDay.person.firstname,
+                expectedEmailMessage,
+            )
+        }.returns(templateVariables)
+
+        val templateId = 3
+        every { mailjetTemplateProperties.updateTemplateId }.returns(templateId)
+
+        service.sendUpdate(sickDay)
+
+        verify {
+            emailService.sendEmailMessage(
+                sickDay.person.receiveEmail,
+                sickDay.person.email,
+                "SickDay update - Ziek, zwak en misselijk",
+                templateVariables,
+                templateId,
+            )
+        }
+    }
+}

--- a/src/test/kotlin/community/flock/eco/workday/services/email/SickDayMailServiceTest.kt
+++ b/src/test/kotlin/community/flock/eco/workday/services/email/SickDayMailServiceTest.kt
@@ -35,15 +35,17 @@ class SickDayMailServiceTest {
 
         val expectedEmailMessage =
             """
-            <p>Je ziekteverzuim voor 'Ziek, zwak en misselijk' is bijgewerkt.<p>
-
-            <ul>
-                <li>Omschrijving: Ziek, zwak en misselijk</li>
-                <li>Van: 13-02-2025</li>
-                <li>Tot en met: 13-02-2025</li>
-                <li>Total aantal verzuimuren: 12.0</li>
-                <li>Status: REQUESTED</li>
-            </ul>
+            <p>Your sick day from 13-02-2025 to 13-02-2025 has been updated.<p>
+            <div>
+                <p>Sick day state:</p>
+                <ul>
+                    <li>Description: Ziek, zwak en misselijk</li>
+                    <li>From: 13-02-2025</li>
+                    <li>Up to and including: 13-02-2025</li>
+                    <li>Total absence hours: 12.0</li>
+                    <li>Status: REQUESTED</li>
+                </ul>
+            </div>
             """.trimIndent()
 
         val templateVariables = JSONObject()
@@ -63,7 +65,7 @@ class SickDayMailServiceTest {
             emailService.sendEmailMessage(
                 sickDay.person.receiveEmail,
                 sickDay.person.email,
-                "SickDay update - Ziek, zwak en misselijk",
+                "Sick day update: 13-02-2025 to 13-02-2025 - Ziek, zwak en misselijk",
                 templateVariables,
                 templateId,
             )

--- a/src/test/kotlin/community/flock/eco/workday/services/email/TravelExpenseMailServiceTest.kt
+++ b/src/test/kotlin/community/flock/eco/workday/services/email/TravelExpenseMailServiceTest.kt
@@ -67,4 +67,3 @@ class TravelExpenseMailServiceTest {
         }
     }
 }
-

--- a/src/test/kotlin/community/flock/eco/workday/services/email/TravelExpenseMailServiceTest.kt
+++ b/src/test/kotlin/community/flock/eco/workday/services/email/TravelExpenseMailServiceTest.kt
@@ -33,15 +33,17 @@ class TravelExpenseMailServiceTest {
 
         val expectedEmailMessage =
             """
-            <p>Je reiskostenvergoeding voor 'Taxirit naar hoofdkantoor Coolblue' is bijgewerkt.<p>
-
-            <ul>
-                <li>Beschrijving: Taxirit naar hoofdkantoor Coolblue</li>
-                <li>Datum van uitgifte: 13-02-2025</li>
-                <li>Afstand: 12.34</li>
-                <li>Kilometervergoeding: 0.33</li>
-                <li>Status: REQUESTED</li>
-            </ul>
+            <p>Your travel expense for 'Taxirit naar hoofdkantoor Coolblue' has been updated.<p>
+            <div>
+                <p>Travel expense state:</p>
+                <ul>
+                    <li>Description: Taxirit naar hoofdkantoor Coolblue</li>
+                    <li>Issue date: 13-02-2025</li>
+                    <li>Distance: 12.34</li>
+                    <li>Allowance: 0.33</li>
+                    <li>Status: REQUESTED</li>
+                </ul>
+            </div>
             """.trimIndent()
         val templateVariables = JSONObject()
         every {
@@ -60,7 +62,7 @@ class TravelExpenseMailServiceTest {
             emailService.sendEmailMessage(
                 travelExpense.person.receiveEmail,
                 travelExpense.person.email,
-                "Reiskostenvergoeding update - Taxirit naar hoofdkantoor Coolblue!",
+                "Travel expense update: Taxirit naar hoofdkantoor Coolblue",
                 templateVariables,
                 templateId,
             )

--- a/src/test/kotlin/community/flock/eco/workday/services/email/TravelExpenseMailServiceTest.kt
+++ b/src/test/kotlin/community/flock/eco/workday/services/email/TravelExpenseMailServiceTest.kt
@@ -1,0 +1,70 @@
+package community.flock.eco.workday.services.email
+
+import community.flock.eco.workday.config.properties.MailjetTemplateProperties
+import community.flock.eco.workday.model.Status
+import community.flock.eco.workday.model.TravelExpense
+import community.flock.eco.workday.model.aPerson
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.json.JSONObject
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.util.UUID
+
+class TravelExpenseMailServiceTest {
+    private val emailService: EmailService = mockk(relaxed = true)
+    private val mailjetTemplateProperties: MailjetTemplateProperties = mockk()
+
+    private val service = TravelExpenseMailService(emailService, mailjetTemplateProperties)
+
+    @Test
+    fun `Send email`() {
+        val travelExpense =
+            TravelExpense(
+                id = UUID.randomUUID(),
+                date = LocalDate.of(2025, 2, 13),
+                description = "Taxirit naar hoofdkantoor Coolblue",
+                person = aPerson(),
+                distance = 12.34,
+                allowance = 0.33,
+                status = Status.REQUESTED,
+            )
+
+        val expectedEmailMessage =
+            """
+            <p>Je reiskostenvergoeding voor 'Taxirit naar hoofdkantoor Coolblue' is bijgewerkt.<p>
+
+            <ul>
+                <li>Beschrijving: Taxirit naar hoofdkantoor Coolblue</li>
+                <li>Datum van uitgifte: 13-02-2025</li>
+                <li>Afstand: 12.34</li>
+                <li>Kilometervergoeding: 0.33</li>
+                <li>Status: REQUESTED</li>
+            </ul>
+            """.trimIndent()
+        val templateVariables = JSONObject()
+        every {
+            emailService.createTemplateVariables(
+                travelExpense.person.firstname,
+                expectedEmailMessage,
+            )
+        }.returns(templateVariables)
+
+        val templateId = 3
+        every { mailjetTemplateProperties.updateTemplateId }.returns(templateId)
+
+        service.sendUpdate(travelExpense)
+
+        verify {
+            emailService.sendEmailMessage(
+                travelExpense.person.receiveEmail,
+                travelExpense.person.email,
+                "Reiskostenvergoeding update - Taxirit naar hoofdkantoor Coolblue!",
+                templateVariables,
+                templateId,
+            )
+        }
+    }
+}
+


### PR DESCRIPTION
### Description
- Modified update email logic to send notifications for LeaveDays, SickDays, TravelExpenses, and CostExpenses only when updated by non-owners.
- Enhanced email content with more contextual information for better clarity.
- Fixed workday email styling by incorporating HTML for improved presentation.

Very similar to #395 

Solves #390 