### PR TITLE
Add pagination to Events and standardize Pagination use in frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "flock-eco-workday",
   "main": "index.js",
   "scripts": {
+    "clean": "npx --yes rimraf ./src/main/react/wirespec",
     "format": "prettier --write './src/main/react/**/*.{js,jsx,ts,tsx}'",
     "lint": "concurrently \"echo Not running eslint yet\" \"npm run lint:prettier\"",
     "lint:fix": "concurrently \"echo Not running eslint yet\" \"npm run lint:prettier:fix\"",

--- a/src/main/kotlin/community/flock/eco/workday/controllers/EventController.kt
+++ b/src/main/kotlin/community/flock/eco/workday/controllers/EventController.kt
@@ -42,21 +42,24 @@ class EventController(
 ) {
     @GetMapping()
     @PreAuthorize("hasAuthority('EventAuthority.READ')")
-    fun getAll(authentication: Authentication,
-               pageable: Pageable) =
-        eventService
-            .findAll(pageable)
-            .map {
-                if (!it.isAuthenticated(authentication)) {
-                    it.copy(
-                        description = "N/A - ${it.description}",
-                        costs = 0.00,
-                        days = null,
-                        persons = listOf(),
-                    )
-                } else it
+    fun getAll(
+        authentication: Authentication,
+        pageable: Pageable,
+    ) = eventService
+        .findAll(pageable)
+        .map {
+            if (!it.isAuthenticated(authentication)) {
+                it.copy(
+                    description = "N/A - ${it.description}",
+                    costs = 0.00,
+                    days = null,
+                    persons = listOf(),
+                )
+            } else {
+                it
             }
-            .toResponse()
+        }
+        .toResponse()
 
     @GetMapping("/hack-days")
     @PreAuthorize("hasAuthority('EventAuthority.SUBSCRIBE')")

--- a/src/main/kotlin/community/flock/eco/workday/services/EventService.kt
+++ b/src/main/kotlin/community/flock/eco/workday/services/EventService.kt
@@ -9,7 +9,8 @@ import community.flock.eco.workday.model.Person
 import community.flock.eco.workday.repository.EventProjection
 import community.flock.eco.workday.repository.EventRatingRepository
 import community.flock.eco.workday.repository.EventRepository
-import org.springframework.data.domain.Sort
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -25,7 +26,7 @@ class EventService(
 ) {
     fun findAll(): Iterable<Event> = eventRepository.findAll()
 
-    fun findAll(sort: Sort): Iterable<Event> = eventRepository.findAll(sort)
+    fun findAll(pageable: Pageable): Page<Event> = eventRepository.findAll(pageable)
 
     fun findAllByPersonUuid(personCode: UUID) =
         eventRepository

--- a/src/main/react/clients/AssignmentClient.ts
+++ b/src/main/react/clients/AssignmentClient.ts
@@ -72,7 +72,13 @@ const internalizingClient = InternalizingClient<
 
 export const ASSIGNMENT_PAGE_SIZE = 5;
 
-const findAllByPersonId = (personId: string, page: number | "all") => {
+const findAllByPersonId: (
+  personId: string,
+  page: number | "all"
+) => Promise<{
+  list: Assignment[];
+  count: number;
+}> = (personId: string, page: number | "all") => {
   if (page === "all") {
     return findAllByPersonIdUnpaged(personId);
   }
@@ -90,9 +96,9 @@ const findAllByPersonId = (personId: string, page: number | "all") => {
 };
 
 const findAllByPersonIdUnpaged = (personId: string) =>
-  internalizingClient.query({
-    personId,
-  });
+  internalizingClient
+    .query({ personId })
+    .then((list) => ({ list: list, count: list.length }));
 
 const findAllByProject = (project: Project) =>
   internalizingClient.query({ projectCode: project.code });

--- a/src/main/react/clients/EventClient.ts
+++ b/src/main/react/clients/EventClient.ts
@@ -99,11 +99,21 @@ const internalizeFull = (it: FlockEventRaw): FullFlockEvent => ({
   costs: it.costs,
 });
 
+export const EVENT_PAGE_SIZE: number = 10;
+
 const internalizingClient = InternalizingClient<
   FlockEventRequest,
   FlockEventRaw,
   FullFlockEvent
 >(path, internalizeFull);
+
+const getAll = (page: number, pageSize = EVENT_PAGE_SIZE) => {
+  return internalizingClient.findAllByPage({
+    page,
+    size: pageSize,
+    sort: "from,desc",
+  });
+};
 
 // TODO: Rating type
 const getRatings = (id) => {
@@ -178,6 +188,7 @@ const unsubscribeFromEvent = (event: FlockEvent) => {
 
 export const EventClient = {
   ...internalizingClient,
+  getAll,
   getRatings,
   postRatings,
   deleteRatings,

--- a/src/main/react/components/selector/AssignmentSelector.tsx
+++ b/src/main/react/components/selector/AssignmentSelector.tsx
@@ -42,7 +42,7 @@ export function AssignmentSelector({
     if (!personId) return;
 
     AssignmentClient.findAllByPersonId(personId, "all").then((res) =>
-      setItems(res)
+      setItems(res.list)
     );
   }, []);
 

--- a/src/main/react/features/assignments/AssignmentList.tsx
+++ b/src/main/react/features/assignments/AssignmentList.tsx
@@ -8,19 +8,14 @@ import {
   AssignmentClient,
 } from "../../clients/AssignmentClient";
 import { isDefined } from "../../utils/validation";
-import { Pagination } from "@material-ui/lab";
 import { makeStyles } from "@material-ui/core/styles";
 import UserAuthorityUtil from "@flock-community/flock-eco-feature-user/src/main/react/user_utils/UserAuthorityUtil";
+import { FlockPagination } from "../../components/pagination/FlockPagination";
 
 const useStyles = makeStyles({
   list: (loading) => ({
     opacity: loading ? 0.5 : 1,
   }),
-  pagination: {
-    "& .MuiPagination-ul": {
-      justifyContent: "right",
-    },
-  },
 });
 
 type AssignmentListProps = {
@@ -35,24 +30,20 @@ export function AssignmentList({
   personId,
   onItemClick,
   disableEdit,
-}: AssignmentListProps) {
+}: Readonly<AssignmentListProps>) {
   const [items, setItems] = useState<any[]>([]);
   const [page, setPage] = useState(0);
-  const [pageCount, setPageCount] = useState(-1);
+  const [count, setCount] = useState(-1);
   const [loading, setLoading] = useState(true);
 
   const classes = useStyles(loading);
-
-  const handleChangePage = (event: object, paginationComponentPage: number) =>
-    // Client page is 0-based, pagination component is 1-based
-    setPage(paginationComponentPage - 1);
 
   useEffect(() => {
     if (personId) {
       setLoading(true);
       AssignmentClient.findAllByPersonId(personId, page).then((res) => {
         setItems(res.list);
-        setPageCount(Math.ceil(res.count / ASSIGNMENT_PAGE_SIZE));
+        setCount(res.count);
         setLoading(false);
       });
     } else {
@@ -107,14 +98,11 @@ export function AssignmentList({
         ))}
       </Grid>
       <Box mt={2}>
-        <Pagination
-          className={classes.pagination}
-          count={pageCount}
-          // Client page is 0-based, pagination component is 1-based
-          page={page + 1}
-          onChange={handleChangePage}
-          shape="rounded"
-          size="small"
+        <FlockPagination
+          currentPage={page + 1}
+          numberOfItems={count}
+          itemsPerPage={ASSIGNMENT_PAGE_SIZE}
+          changePageCb={setPage}
         />
       </Box>
     </>

--- a/src/main/react/features/contract/ContractList.tsx
+++ b/src/main/react/features/contract/ContractList.tsx
@@ -9,18 +9,13 @@ import {
   ContractClient,
 } from "../../clients/ContractClient";
 import { ContractType } from "./ContractType";
-import { Pagination } from "@material-ui/lab";
 import { makeStyles } from "@material-ui/core/styles";
+import { FlockPagination } from "../../components/pagination/FlockPagination";
 
 const useStyles = makeStyles({
   list: (loading) => ({
     opacity: loading ? 0.5 : 1,
   }),
-  pagination: {
-    "& .MuiPagination-ul": {
-      justifyContent: "right",
-    },
-  },
 });
 
 type ContractListProps = {
@@ -32,24 +27,20 @@ export function ContractList({
   reload,
   personId,
   onItemClick,
-}: ContractListProps) {
+}: Readonly<ContractListProps>) {
   const [items, setItems] = useState<any[]>([]);
   const [page, setPage] = useState(0);
-  const [pageCount, setPageCount] = useState(-1);
+  const [count, setCount] = useState(-1);
   const [loading, setLoading] = useState(true);
 
   const classes = useStyles(loading);
-
-  const handleChangePage = (event: object, paginationComponentPage: number) =>
-    // Client page is 0-based, pagination component is 1-based
-    setPage(paginationComponentPage - 1);
 
   useEffect(() => {
     if (personId) {
       setLoading(true);
       ContractClient.findAllByPersonId(personId, page).then((res) => {
         setItems(res.list);
-        setPageCount(Math.ceil(res.count / CONTRACT_PAGE_SIZE));
+        setCount(res.count);
         setLoading(false);
       });
     }
@@ -104,14 +95,11 @@ export function ContractList({
         ))}
       </Grid>
       <Box mt={2}>
-        <Pagination
-          className={classes.pagination}
-          count={pageCount}
-          // Client page is 0-based, pagination component is 1-based
-          page={page + 1}
-          onChange={handleChangePage}
-          shape="rounded"
-          size="small"
+        <FlockPagination
+          currentPage={page + 1}
+          numberOfItems={count}
+          itemsPerPage={CONTRACT_PAGE_SIZE}
+          changePageCb={setPage}
         />
       </Box>
     </>


### PR DESCRIPTION
This a is two part PR, addressing issue around Pagination


# ✨ **Feature**
Added pagination to events

Old situation. `/events` returned ALL events, sorted by `from` date, ascending. This results in a poor UX, where you're typically interested in more recent events, rather than ones form years ago.

Proposed solution: In line with other 'list' features, I've added server side pagination, and sort the collection DESC, causing the latest events to be on top.

## Old situation

![Screen Recording 2025-02-10 at 16 50 06](https://github.com/user-attachments/assets/269619e2-d60a-42af-8c55-eedb0578d864)

## New Situation

![Screen Recording 2025-02-10 at 16 50 30](https://github.com/user-attachments/assets/df535349-61e9-4b76-bd2b-35ee5a095852)



## 🧹**Chore**
The use of pagination in the various 'list' components was inconsistent, sometimes using the `FlockPagination`, sometimes not. I've tried to align this to using the `FlockPagination` everywhere.

See this commit:
https://github.com/flock-community/flock-eco-workday/pull/407/commits/df7ead3eea681399fad7003bb0b1fbac5625d255


Here's an  example of the ContractList update list. Left is the *new* version:


![Screenshot 2025-02-10 at 17 00 06](https://github.com/user-attachments/assets/be99e932-1bc1-4a69-9e35-2d5acec45add)

