### PR TITLE
Allow Dependabot PRs to run CI/CD pipeline without GCP access

### DIFF
--- a/.github/workflows/gcp.yml
+++ b/.github/workflows/gcp.yml
@@ -24,18 +24,22 @@ jobs:
 
       - id: "auth"
         name: "Authenticate to Google Cloud"
+        if: github.actor != 'dependabot[bot]'
         uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDED }}
           service_account: ${{ secrets.GCP_SA_EMAIL }}
 
       - name: Setup gcloud environment
+        if: github.actor != 'dependabot[bot]'
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Google cloud info
+        if: github.actor != 'dependabot[bot]'
         run: gcloud info
 
       - name: Setup docker
+        if: github.actor != 'dependabot[bot]'
         run: gcloud auth configure-docker
 
       - uses: actions/setup-java@v4
@@ -129,7 +133,9 @@ jobs:
           fi
 
       - name: Build and Deploy
+        if: github.actor != 'dependabot[bot]' && github.ref != 'refs/heads/master'
         run: ./mvnw -B clean package jib:build -DskipTests -Pfrontend -Dnpm.ci.skip -Djib.to.image=eu.gcr.io/flock-community/flock-eco-workday -Djib.to.tags=${{ github.sha }} --file pom.xml
 
       - name: Build and Deploy Development version
+        if: github.actor != 'dependabot[bot]'
         run: ./mvnw -B package jib:build -DskipTests -Pdevelop,frontend -Dnpm.ci.skip -Dnpm.skip -Djib.container.environment=SPRING_PROFILES_ACTIVE=develop -Djib.to.image=eu.gcr.io/flock-community/flock-eco-workday-develop -Djib.to.tags=${{ github.sha }} --file pom.xml


### PR DESCRIPTION
## Summary
- Configure CI/CD workflow to allow Dependabot PRs to run full test suite without requiring GCP credentials
- Skip GCP authentication and deployment steps for Dependabot PRs
- Update production deployment to only run on PRs (not master branch)

## Changes Made
1. **Added conditionals to skip GCP steps for Dependabot:**
   - Authenticate to Google Cloud
   - Setup gcloud environment
   - Google cloud info
   - Setup docker

2. **Added conditionals to skip deployment steps for Dependabot:**
   - Build and Deploy (production image)
   - Build and Deploy Development version

3. **Updated production deploy logic:**
   - Production image (`flock-eco-workday`) now only deploys on PRs, not master
   - Development image (`flock-eco-workday-develop`) continues to deploy on master and PRs

## Deployment Behavior After Changes
| Event | Production Deploy | Development Deploy |
|-------|------------------|-------------------|
| PR (regular) | ✅ Yes | ✅ Yes |
| PR (Dependabot) | ❌ No | ❌ No |
| Master push | ❌ No | ✅ Yes |

## Test Coverage
Dependabot PRs will still run:
- ✅ Ktlint checks
- ✅ ESLint/Prettier
- ✅ npm unit tests
- ✅ Full Maven build
- ✅ Playwright e2e tests

## Why This Change?
Currently Dependabot PRs fail because they don't have access to GCP secrets. This change allows Dependabot to validate code quality and run tests without deployment capabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)