### PR TITLE
Replace `setup-java` caching with `actions/cache` in GCP workflow

### DIFF
--- a/.github/workflows/gcp.yml
+++ b/.github/workflows/gcp.yml
@@ -46,7 +46,14 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "17"
-          cache: "maven"
+
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
```
### Description

This pull request updates the GCP workflow to replace `setup-java` caching with `actions/cache` for Maven dependencies.

#### Reason for Change:
- Increase cache hits for Maven dependencies to optimize workflow performance.

### Checklist

- [ ] Code changes have been tested
- [ ] Documentation has been updated (if applicable)
- [ ] Changes have been reviewed by at least one peer
```
