### PR TITLE
Update `ConditionalOnProperty` defaults and add local storage warning

### DIFF
--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/services/GcpDocumentService.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/services/GcpDocumentService.kt
@@ -11,13 +11,17 @@ import org.springframework.stereotype.Service
 import java.util.UUID
 
 @Service
-@ConditionalOnProperty(name = ["flock.eco.workday.google.enabled"], havingValue = "true")
+@ConditionalOnProperty(name = ["flock.eco.workday.google.enabled"], havingValue = "true", matchIfMissing = true)
 class GcpDocumentService(
     @Value("\${flock.eco.workday.bucket.documents}") val bucketName: String,
 ) : DocumentStorage {
     companion object {
         val storage: Storage = StorageOptions.getDefaultInstance().service
         var logger: Logger = LoggerFactory.getLogger(GcpDocumentService::class.java)
+    }
+
+    init {
+        logger.info("Using GCP storage for documents")
     }
 
     override fun storeDocument(byteArray: ByteArray): UUID {

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/services/LocalDocumentService.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/services/LocalDocumentService.kt
@@ -10,7 +10,7 @@ import java.nio.file.Paths
 import java.util.UUID
 
 @Service
-@ConditionalOnProperty(name = ["flock.eco.workday.google.enabled"], havingValue = "false", matchIfMissing = true)
+@ConditionalOnProperty(name = ["flock.eco.workday.google.enabled"], havingValue = "false", matchIfMissing = false)
 class LocalDocumentService : DocumentStorage {
     companion object {
         const val DOCUMENTS_PATH = "database/documents"
@@ -19,6 +19,7 @@ class LocalDocumentService : DocumentStorage {
 
     init {
         // Ensure the documents directory exists
+        logger.warn("⚠️⚠️ Using local file storage for documents")
         val documentsDir = File(DOCUMENTS_PATH)
         if (!documentsDir.exists()) {
             documentsDir.mkdirs()

--- a/workday-application/src/test/resources/application-test.properties
+++ b/workday-application/src/test/resources/application-test.properties
@@ -1,4 +1,5 @@
 flock.eco.cloud.stub.enabled=true
+flock.eco.workday.google.enabled=false
 flock.eco.workday.bucket.documents=test-bucket
 flock.eco.workday.calendar.token=sesamstraat
 google.drive.sheets.workday.templateId=none


### PR DESCRIPTION
- Adjusted `matchIfMissing` defaults in `LocalDocumentService` and `GcpDocumentService` to align with expected behavior.
- Added a warning log in `LocalDocumentService` to notify users about the use of local file storage.