### PR TITLE
Refactor ClientController to use endpoint handlers pattern

### DIFF
--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/ClientController.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/ClientController.kt
@@ -1,67 +1,80 @@
 package community.flock.eco.workday.application.controllers
 
+import community.flock.eco.workday.api.endpoint.DeleteClient
+import community.flock.eco.workday.api.endpoint.GetClientAll
+import community.flock.eco.workday.api.endpoint.GetClientByCode
+import community.flock.eco.workday.api.endpoint.PostClient
+import community.flock.eco.workday.api.endpoint.PutClient
 import community.flock.eco.workday.application.forms.ClientForm
-import community.flock.eco.workday.application.model.Client
 import community.flock.eco.workday.application.services.ClientService
-import community.flock.eco.workday.core.utils.toResponse
-import org.springframework.data.domain.Pageable
-import org.springframework.http.ResponseEntity
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import community.flock.eco.workday.api.model.Client as ClientApi
+import community.flock.eco.workday.api.model.ClientForm as ClientFormApi
+import community.flock.eco.workday.application.model.Client as ClientInternal
 
 @RestController
-@RequestMapping("/api/clients")
 class ClientController(
     private val clientService: ClientService,
-) {
-    @GetMapping
+) : GetClientAll.Handler,
+    GetClientByCode.Handler,
+    PostClient.Handler,
+    PutClient.Handler,
+    DeleteClient.Handler {
     @PreAuthorize("hasAuthority('ClientAuthority.READ')")
-    fun findAll(pageable: Pageable): ResponseEntity<List<Client>> =
-        clientService
-            .findAll(pageable)
-            .toResponse()
+    override suspend fun getClientAll(request: GetClientAll.Request): GetClientAll.Response<*> {
+        val pageable = request.queries.pageable
+        val sort = pageable.sort?.takeIf { it.isNotEmpty() }?.let { Sort.by(*it.toTypedArray()) } ?: Sort.unsorted()
+        val page = PageRequest.of(pageable.page, pageable.size, sort)
+        return GetClientAll.Response200(
+            clientService
+                .findAll(page)
+                .content
+                .map { it.externalize() },
+        )
+    }
 
-    @GetMapping("/{code}")
     @PreAuthorize("hasAuthority('ClientAuthority.READ')")
-    fun findByCode(
-        @PathVariable code: String,
-    ): ResponseEntity<Client> =
-        clientService
-            .findByCode(code)
-            .toResponse()
+    override suspend fun getClientByCode(request: GetClientByCode.Request): GetClientByCode.Response<*> {
+        val client =
+            clientService.findByCode(request.path.code)
+                ?: error("Client with code ${request.path.code} not found")
+        return GetClientByCode.Response200(client.externalize())
+    }
 
-    @PostMapping
     @PreAuthorize("hasAuthority('ClientAuthority.WRITE')")
-    fun post(
-        @RequestBody form: ClientForm,
-    ): ResponseEntity<Client> =
-        clientService
-            .create(form)
-            .toResponse()
+    override suspend fun postClient(request: PostClient.Request): PostClient.Response<*> {
+        val client =
+            clientService.create(request.body.internalize())
+                ?: error("Could not create client")
+        return PostClient.Response200(client.externalize())
+    }
 
-    @PutMapping("{code}")
     @PreAuthorize("hasAuthority('ClientAuthority.WRITE')")
-    fun put(
-        @PathVariable code: String,
-        @RequestBody form: ClientForm,
-    ): ResponseEntity<Client> =
-        clientService
-            .update(code, form)
-            .toResponse()
+    override suspend fun putClient(request: PutClient.Request): PutClient.Response<*> {
+        val client =
+            clientService.update(request.path.code, request.body.internalize())
+                ?: error("Client with code ${request.path.code} not found")
+        return PutClient.Response200(client.externalize())
+    }
 
-    @DeleteMapping("{code}")
     @PreAuthorize("hasAuthority('ClientAuthority.WRITE')")
-    fun delete(
-        @PathVariable code: String,
-    ): ResponseEntity<Unit> =
-        clientService
-            .delete(code)
-            .toResponse()
+    override suspend fun deleteClient(request: DeleteClient.Request): DeleteClient.Response<*> {
+        clientService.delete(request.path.code)
+        return DeleteClient.Response200(Unit)
+    }
+
+    private fun ClientInternal.externalize() =
+        ClientApi(
+            id = id,
+            code = code,
+            name = name,
+        )
+
+    private fun ClientFormApi.internalize() =
+        ClientForm(
+            name = name ?: "",
+        )
 }

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/ClientController.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/ClientController.kt
@@ -7,8 +7,6 @@ import community.flock.eco.workday.api.endpoint.PostClient
 import community.flock.eco.workday.api.endpoint.PutClient
 import community.flock.eco.workday.application.forms.ClientForm
 import community.flock.eco.workday.application.services.ClientService
-import org.springframework.data.domain.PageRequest
-import org.springframework.data.domain.Sort
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RestController
 import community.flock.eco.workday.api.model.Client as ClientApi
@@ -24,17 +22,12 @@ class ClientController(
     PutClient.Handler,
     DeleteClient.Handler {
     @PreAuthorize("hasAuthority('ClientAuthority.READ')")
-    override suspend fun getClientAll(request: GetClientAll.Request): GetClientAll.Response<*> {
-        val pageable = request.queries.pageable
-        val sort = pageable.sort?.takeIf { it.isNotEmpty() }?.let { Sort.by(*it.toTypedArray()) } ?: Sort.unsorted()
-        val page = PageRequest.of(pageable.page, pageable.size, sort)
-        return GetClientAll.Response200(
+    override suspend fun getClientAll(request: GetClientAll.Request): GetClientAll.Response<*> =
+        GetClientAll.Response200(
             clientService
-                .findAll(page)
-                .content
+                .findAll()
                 .map { it.externalize() },
         )
-    }
 
     @PreAuthorize("hasAuthority('ClientAuthority.READ')")
     override suspend fun getClientByCode(request: GetClientByCode.Request): GetClientByCode.Response<*> {

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/ClientController.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/ClientController.kt
@@ -7,6 +7,8 @@ import community.flock.eco.workday.api.endpoint.PostClient
 import community.flock.eco.workday.api.endpoint.PutClient
 import community.flock.eco.workday.application.forms.ClientForm
 import community.flock.eco.workday.application.services.ClientService
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RestController
 import community.flock.eco.workday.api.model.Client as ClientApi
@@ -22,12 +24,19 @@ class ClientController(
     PutClient.Handler,
     DeleteClient.Handler {
     @PreAuthorize("hasAuthority('ClientAuthority.READ')")
-    override suspend fun getClientAll(request: GetClientAll.Request): GetClientAll.Response<*> =
-        GetClientAll.Response200(
+    override suspend fun getClientAll(request: GetClientAll.Request): GetClientAll.Response<*> {
+        val page = PageRequest.of(
+            request.queries.page ?: 0,
+            request.queries.size ?: 20,
+            request.queries.sort?.toSort() ?: Sort.unsorted(),
+        )
+        return GetClientAll.Response200(
             clientService
-                .findAll()
+                .findAll(page)
+                .content
                 .map { it.externalize() },
         )
+    }
 
     @PreAuthorize("hasAuthority('ClientAuthority.READ')")
     override suspend fun getClientByCode(request: GetClientByCode.Request): GetClientByCode.Response<*> {
@@ -70,4 +79,20 @@ class ClientController(
         ClientForm(
             name = name ?: "",
         )
+
+    private fun String.toSort(): Sort =
+        split(",")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .let { parts ->
+                when {
+                    parts.isEmpty() -> Sort.unsorted()
+                    parts.size == 1 -> Sort.by(parts[0])
+                    parts.last().equals("asc", ignoreCase = true) ->
+                        Sort.by(Sort.Direction.ASC, *parts.dropLast(1).toTypedArray())
+                    parts.last().equals("desc", ignoreCase = true) ->
+                        Sort.by(Sort.Direction.DESC, *parts.dropLast(1).toTypedArray())
+                    else -> Sort.by(*parts.toTypedArray())
+                }
+            }
 }

--- a/workday-application/src/main/wirespec/clients.ws
+++ b/workday-application/src/main/wirespec/clients.ws
@@ -1,4 +1,4 @@
-endpoint GetClientAll GET /api/clients -> {
+endpoint GetClientAll GET /api/clients ? {page: Integer32?, size: Integer32?, sort: String?} -> {
   200 -> Client[]
 }
 endpoint GetClientByCode GET /api/clients/{code: String} -> {

--- a/workday-application/src/main/wirespec/clients.ws
+++ b/workday-application/src/main/wirespec/clients.ws
@@ -1,4 +1,4 @@
-endpoint GetClientAll GET /api/clients ? {pageable: Pageable} -> {
+endpoint GetClientAll GET /api/clients -> {
   200 -> Client[]
 }
 endpoint GetClientByCode GET /api/clients/{code: String} -> {

--- a/workday-application/src/main/wirespec/clients.ws
+++ b/workday-application/src/main/wirespec/clients.ws
@@ -1,17 +1,17 @@
-endpoint FindByCode_6 GET /api/clients/{code: String} -> {
-  200 -> Client
-}
-endpoint Put_5 PUT ClientForm /api/clients/{code: String} -> {
-  200 -> Client
-}
-endpoint Delete_7 DELETE /api/clients/{code: String} -> {
-  200 -> Unit
-}
-endpoint FindAll_1 GET /api/clients ? {pageable: Pageable} -> {
+endpoint GetClientAll GET /api/clients ? {pageable: Pageable} -> {
   200 -> Client[]
 }
-endpoint Post_5 POST ClientForm /api/clients -> {
+endpoint GetClientByCode GET /api/clients/{code: String} -> {
   200 -> Client
+}
+endpoint PostClient POST ClientForm /api/clients -> {
+  200 -> Client
+}
+endpoint PutClient PUT ClientForm /api/clients/{code: String} -> {
+  200 -> Client
+}
+endpoint DeleteClient DELETE /api/clients/{code: String} -> {
+  200 -> Unit
 }
 
 type ClientForm {


### PR DESCRIPTION
## Summary
Refactored the `ClientController` to implement a new endpoint handler pattern, moving away from Spring's `@RequestMapping` and HTTP method annotations to a more structured, interface-based approach. This change improves API consistency and maintainability by centralizing endpoint definitions.

## Key Changes
- **Migrated from Spring annotations to endpoint handlers**: Removed `@GetMapping`, `@PostMapping`, `@PutMapping`, and `@DeleteMapping` annotations and replaced them with interface implementations (`GetClientAll.Handler`, `GetClientByCode.Handler`, `PostClient.Handler`, `PutClient.Handler`, `DeleteClient.Handler`)
- **Implemented request/response pattern**: Each handler method now receives a typed `Request` object and returns a typed `Response` object, providing better type safety and consistency
- **Added model externalization/internalization**: Introduced `externalize()` and `internalize()` extension functions to convert between internal domain models (`ClientInternal`) and API models (`ClientApi`)
- **Updated endpoint definitions**: Reorganized and renamed endpoints in `clients.ws` wirespec file for clarity (e.g., `FindByCode_6` → `GetClientByCode`, `Post_5` → `PostClient`)
- **Improved error handling**: Replaced optional returns with explicit error messages when resources are not found
- **Made handlers suspend functions**: All handler methods are now `suspend` functions, enabling async/coroutine support

## Notable Implementation Details
- Explicit type aliases distinguish between internal (`ClientInternal`) and API (`ClientApi`) models
- Pagination handling now explicitly constructs `PageRequest` with sort parameters from the request
- All handlers maintain the same `@PreAuthorize` security annotations for authorization checks
- The controller no longer declares a base `@RequestMapping` path; routing is now defined in the wirespec

https://claude.ai/code/session_013MxfrxF1iBEziqSRJcouPL