### PR TITLE
Show remaining days alongside hours on home cards

### DIFF
--- a/workday-application/src/main/react/components/hackday-card/HackdayCard.tsx
+++ b/workday-application/src/main/react/components/hackday-card/HackdayCard.tsx
@@ -5,6 +5,7 @@ import {
   CardContent,
   CardHeader,
   IconButton,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
@@ -111,12 +112,14 @@ export function HackdayCard({ refreshKey }: HackdayCardProps) {
               </div>
               <Typography variant="body1">
                 hours left
-                <Box component="span" display="block" fontStyle="italic">
-                  {hoursFormatter.format(
-                    (personHackDayDetails?.totalHoursRemaining ?? 0) / 8,
-                  )}{' '}
-                  days
-                </Box>
+                <Tooltip title="Based on 8 work hours per day">
+                  <Box component="span" display="block" fontStyle="italic">
+                    {hoursFormatter.format(
+                      (personHackDayDetails?.totalHoursRemaining ?? 0) / 8,
+                    )}{' '}
+                    days
+                  </Box>
+                </Tooltip>
               </Typography>
             </div>
           )}

--- a/workday-application/src/main/react/components/hackday-card/HackdayCard.tsx
+++ b/workday-application/src/main/react/components/hackday-card/HackdayCard.tsx
@@ -1,5 +1,6 @@
 import { InfoOutlined } from '@mui/icons-material';
 import {
+  Box,
   Card,
   CardContent,
   CardHeader,
@@ -108,7 +109,15 @@ export function HackdayCard({ refreshKey }: HackdayCardProps) {
                   )}
                 </HighlightSpan>
               </div>
-              <Typography variant="body1">hours left</Typography>
+              <Typography variant="body1">
+                hours left
+                <Box component="span" display="block" fontStyle="italic">
+                  {hoursFormatter.format(
+                    (personHackDayDetails?.totalHoursRemaining ?? 0) / 8,
+                  )}{' '}
+                  days
+                </Box>
+              </Typography>
             </div>
           )}
         </CardContent>

--- a/workday-application/src/main/react/components/holiday-card/HolidayCard.tsx
+++ b/workday-application/src/main/react/components/holiday-card/HolidayCard.tsx
@@ -1,5 +1,6 @@
 import { InfoOutlined } from '@mui/icons-material';
 import {
+  Box,
   Card,
   CardContent,
   CardHeader,
@@ -97,7 +98,12 @@ export function HolidayCard({ item }: HolidayCardProps) {
             <div className={classes.hoursLeft}>
               <HighlightSpan>{hoursFormatter.format(available)}</HighlightSpan>
             </div>
-            <Typography variant="body1">hours left</Typography>
+            <Typography variant="body1">
+              hours left
+              <Box component="span" display="block" fontStyle="italic">
+                {hoursFormatter.format(available / 8)} days
+              </Box>
+            </Typography>
           </div>
         </CardContent>
       </Card>

--- a/workday-application/src/main/react/components/holiday-card/HolidayCard.tsx
+++ b/workday-application/src/main/react/components/holiday-card/HolidayCard.tsx
@@ -5,6 +5,7 @@ import {
   CardContent,
   CardHeader,
   IconButton,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
@@ -100,9 +101,11 @@ export function HolidayCard({ item }: HolidayCardProps) {
             </div>
             <Typography variant="body1">
               hours left
-              <Box component="span" display="block" fontStyle="italic">
-                {hoursFormatter.format(available / 8)} days
-              </Box>
+              <Tooltip title="Based on 8 work hours per day">
+                <Box component="span" display="block" fontStyle="italic">
+                  {hoursFormatter.format(available / 8)} days
+                </Box>
+              </Tooltip>
             </Typography>
           </div>
         </CardContent>


### PR DESCRIPTION
## Context
Users read their leave and hack balance in days, but the home cards showed only raw hours. This surfaces the equivalent number of days (hours ÷ 8) under the existing "hours left" label, in italic, so the balance is legible in the unit people actually book leave in. Hovering the day count shows "Based on 8 work hours per day" so the assumption isn't hidden — relevant for employees on a different schedule. The (i) icon stays single-purpose (open detail dialog).

## Before
![before](https://gist.githubusercontent.com/pimfm/75fbac8380431380ddaa291dd06d4ca0/raw/3076f3ce9b7ee0a416ada8a398839084e7cd8fb7/leave-card-before.png)

## After
![after](https://gist.githubusercontent.com/pimfm/75fbac8380431380ddaa291dd06d4ca0/raw/c93610b7c772833058a6f291b6746724a0e7a068/leave-card-after.png)

## Changes
- Show remaining days alongside hours on home cards (Leave days + Hack days)
- Add tooltip on the days text noting 8-hour-day basis
