### PR TITLE
Soft-warn hackdays and leave days in WorkDayForm

### DIFF
--- a/workday-application/src/main/react/components/fields/PeriodInputField.tsx
+++ b/workday-application/src/main/react/components/fields/PeriodInputField.tsx
@@ -11,6 +11,7 @@ import {
   mutatePeriod,
   type Period,
 } from '../../features/period/Period';
+import type { DayMeta } from '../../hooks/DayMetaHook';
 import { PeriodInput } from '../inputs/PeriodInput';
 
 const PREFIX = 'PeriodInputField';
@@ -30,6 +31,7 @@ type PeriodInputFieldProps = {
   from: dayjs.Dayjs;
   to: dayjs.Dayjs;
   reset?: boolean;
+  dayMeta?: Map<string, DayMeta>;
 };
 
 function PeriodInputRenderer({
@@ -39,6 +41,7 @@ function PeriodInputRenderer({
   reset,
   value,
   setFieldValue,
+  dayMeta,
 }: Readonly<PeriodInputRendererProps>) {
   const [period, setPeriod] = useState<Period>({
     from,
@@ -83,7 +86,11 @@ function PeriodInputRenderer({
 
   return (
     <>
-      <PeriodInput period={period} onChange={handlePeriodChange} />
+      <PeriodInput
+        period={period}
+        onChange={handlePeriodChange}
+        dayMeta={dayMeta}
+      />
       <ButtonGroup className={classes.buttons} size="small" fullWidth>
         <Button variant="outlined" onClick={() => setHoursPerDay(0)}>
           Clear all
@@ -106,6 +113,7 @@ type PeriodInputRendererProps = {
   reset?: boolean;
   value: any;
   setFieldValue: (field: string, value: unknown) => void;
+  dayMeta?: Map<string, DayMeta>;
 };
 
 export function PeriodInputField({
@@ -113,6 +121,7 @@ export function PeriodInputField({
   from,
   to,
   reset,
+  dayMeta,
 }: Readonly<PeriodInputFieldProps>) {
   return (
     <StyledField id={name} name={name}>
@@ -124,6 +133,7 @@ export function PeriodInputField({
           reset={reset}
           value={value}
           setFieldValue={setFieldValue}
+          dayMeta={dayMeta}
         />
       )}
     </StyledField>

--- a/workday-application/src/main/react/components/inputs/PeriodInput.tsx
+++ b/workday-application/src/main/react/components/inputs/PeriodInput.tsx
@@ -21,26 +21,29 @@ export type PeriodInputProps = {
 
 type CellStyle = {
   borderColor: string;
-  borderStyle: 'solid' | 'dashed';
+  borderStyle: 'solid' | 'dashed' | 'dotted';
   background: string;
 };
 
+// Flock-aligned palette: green for hackdays, sun-yellow for leave.
+// Approved leave is solid yellow; requested leave is the same hue but dotted
+// to imply "not yet final".
 const HACKDAY_STYLE: CellStyle = {
-  borderColor: 'info.main',
+  borderColor: '#2E7D32',
   borderStyle: 'solid',
-  background: 'rgba(2, 136, 209, 0.08)',
+  background: 'rgba(46, 125, 50, 0.08)',
 };
 
-const LEAVE_FINAL_STYLE: CellStyle = {
-  borderColor: 'warning.main',
+const LEAVE_APPROVED_STYLE: CellStyle = {
+  borderColor: '#F5B800',
   borderStyle: 'solid',
-  background: 'rgba(237, 108, 2, 0.10)',
+  background: 'rgba(245, 184, 0, 0.14)',
 };
 
 const LEAVE_REQUESTED_STYLE: CellStyle = {
-  borderColor: 'warning.light',
-  borderStyle: 'dashed',
-  background: 'rgba(237, 108, 2, 0.04)',
+  borderColor: '#F5B800',
+  borderStyle: 'dotted',
+  background: 'rgba(245, 184, 0, 0.05)',
 };
 
 const cellStyleFor = (meta: DayMeta | undefined): CellStyle | undefined => {
@@ -49,7 +52,7 @@ const cellStyleFor = (meta: DayMeta | undefined): CellStyle | undefined => {
   if (meta.leave) {
     return meta.leave.status === 'REQUESTED'
       ? LEAVE_REQUESTED_STYLE
-      : LEAVE_FINAL_STYLE;
+      : LEAVE_APPROVED_STYLE;
   }
   return undefined;
 };

--- a/workday-application/src/main/react/components/inputs/PeriodInput.tsx
+++ b/workday-application/src/main/react/components/inputs/PeriodInput.tsx
@@ -1,9 +1,10 @@
-import { Box, TextField } from '@mui/material';
+import { Box, TextField, Tooltip } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import dayjs, { type Dayjs } from 'dayjs';
 import weekOfYearPlugin from 'dayjs/plugin/weekOfYear';
 import type { Period } from '../../features/period/Period';
+import type { DayMeta } from '../../hooks/DayMetaHook';
 
 // utils
 import { calcGrid } from '../../utils/calcGrid';
@@ -15,9 +16,57 @@ const daysOfWeek = ['Ma', 'Di', 'Wo', 'Do', 'Vr', 'Za', 'Zo'];
 export type PeriodInputProps = {
   period: Period;
   onChange: (day: Dayjs, hours: number) => void;
+  dayMeta?: Map<string, DayMeta>;
 };
 
-export function PeriodInput({ period, onChange }: PeriodInputProps) {
+type CellStyle = {
+  borderColor: string;
+  borderStyle: 'solid' | 'dashed';
+  background: string;
+};
+
+const HACKDAY_STYLE: CellStyle = {
+  borderColor: 'info.main',
+  borderStyle: 'solid',
+  background: 'rgba(2, 136, 209, 0.08)',
+};
+
+const LEAVE_FINAL_STYLE: CellStyle = {
+  borderColor: 'warning.main',
+  borderStyle: 'solid',
+  background: 'rgba(237, 108, 2, 0.10)',
+};
+
+const LEAVE_REQUESTED_STYLE: CellStyle = {
+  borderColor: 'warning.light',
+  borderStyle: 'dashed',
+  background: 'rgba(237, 108, 2, 0.04)',
+};
+
+const cellStyleFor = (meta: DayMeta | undefined): CellStyle | undefined => {
+  if (!meta) return undefined;
+  if (meta.hackday) return HACKDAY_STYLE;
+  if (meta.leave) {
+    return meta.leave.status === 'REQUESTED'
+      ? LEAVE_REQUESTED_STYLE
+      : LEAVE_FINAL_STYLE;
+  }
+  return undefined;
+};
+
+const tooltipFor = (meta: DayMeta | undefined): string | undefined => {
+  if (!meta) return undefined;
+  const parts: string[] = [];
+  if (meta.hackday) parts.push(`Hackday: ${meta.hackday.description}`);
+  if (meta.leave) {
+    const label = meta.leave.description ?? meta.leave.type;
+    const statusLabel = meta.leave.status === 'REQUESTED' ? ' (requested)' : '';
+    parts.push(`${label}${statusLabel}`);
+  }
+  return parts.length > 0 ? parts.join(' · ') : undefined;
+};
+
+export function PeriodInput({ period, onChange, dayMeta }: PeriodInputProps) {
   const grid = calcGrid(period);
 
   const totalHoursForPeriod = period.days?.reduce(
@@ -57,8 +106,25 @@ export function PeriodInput({ period, onChange }: PeriodInputProps) {
             <Grid size={{ xs: 2 }}>
               <Typography>{week.weekNumber}</Typography>
             </Grid>
-            {week.days?.map((day) => (
-              <Grid size="grow" key={`day-${day.key}`}>
+            {week.days?.map((day) => {
+              const meta = day.disabled ? undefined : dayMeta?.get(day.key);
+              const style = cellStyleFor(meta);
+              const tooltip = tooltipFor(meta);
+              const sx = style
+                ? {
+                    backgroundColor: style.background,
+                    '& .MuiOutlinedInput-notchedOutline': {
+                      borderColor: style.borderColor,
+                      borderStyle: style.borderStyle,
+                      borderWidth: 2,
+                    },
+                    '&:hover .MuiOutlinedInput-notchedOutline, & .Mui-focused .MuiOutlinedInput-notchedOutline':
+                      {
+                        borderColor: style.borderColor,
+                      },
+                  }
+                : undefined;
+              const field = (
                 <TextField
                   size="small"
                   label={day.disabled ? '-' : day.date.format('DD MMM')}
@@ -68,9 +134,21 @@ export function PeriodInput({ period, onChange }: PeriodInputProps) {
                     onChange(day.date, parseFloat(ev.target.value || '0'))
                   }
                   type="number"
+                  sx={sx}
                 />
-              </Grid>
-            ))}
+              );
+              return (
+                <Grid size="grow" key={`day-${day.key}`}>
+                  {tooltip ? (
+                    <Tooltip title={tooltip} arrow>
+                      <span>{field}</span>
+                    </Tooltip>
+                  ) : (
+                    field
+                  )}
+                </Grid>
+              );
+            })}
             <Grid size={{ xs: 2 }}>
               <Typography align="right">{week.total}</Typography>
             </Grid>

--- a/workday-application/src/main/react/components/inputs/PeriodInput.tsx
+++ b/workday-application/src/main/react/components/inputs/PeriodInput.tsx
@@ -1,4 +1,4 @@
-import { Box, TextField, Tooltip } from '@mui/material';
+import { Box, InputAdornment, TextField, Tooltip } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import dayjs, { type Dayjs } from 'dayjs';
@@ -19,37 +19,23 @@ export type PeriodInputProps = {
   dayMeta?: Map<string, DayMeta>;
 };
 
-type CellStyle = {
-  borderColor: string;
-  borderStyle: 'solid' | 'dashed';
+type CellAdornment = {
+  icon: string;
+  opacity: number;
 };
 
-// Subtle bottom-border indicators only. Green + purple stays distinct under
-// red-green colourblindness (deuteranopia/protanopia) and on the blue-yellow
-// axis (tritanopia), and avoids the "warning/error" connotation that
-// yellow/orange carries.
-const HACKDAY_STYLE: CellStyle = {
-  borderColor: '#2E7D32',
-  borderStyle: 'solid',
-};
+const HACKDAY_ICON = '💻';
+const LEAVE_ICON = '🌴';
 
-const LEAVE_APPROVED_STYLE: CellStyle = {
-  borderColor: '#7E57C2',
-  borderStyle: 'solid',
-};
-
-const LEAVE_REQUESTED_STYLE: CellStyle = {
-  borderColor: '#7E57C2',
-  borderStyle: 'dashed',
-};
-
-const cellStyleFor = (meta: DayMeta | undefined): CellStyle | undefined => {
+const adornmentFor = (meta: DayMeta | undefined): CellAdornment | undefined => {
   if (!meta) return undefined;
-  if (meta.hackday) return HACKDAY_STYLE;
+  if (meta.hackday) return { icon: HACKDAY_ICON, opacity: 1 };
   if (meta.leave) {
-    return meta.leave.status === 'REQUESTED'
-      ? LEAVE_REQUESTED_STYLE
-      : LEAVE_APPROVED_STYLE;
+    return {
+      icon: LEAVE_ICON,
+      // Requested leave is rendered dimmer to imply "not yet final".
+      opacity: meta.leave.status === 'REQUESTED' ? 0.45 : 1,
+    };
   }
   return undefined;
 };
@@ -108,21 +94,22 @@ export function PeriodInput({ period, onChange, dayMeta }: PeriodInputProps) {
             </Grid>
             {week.days?.map((day) => {
               const meta = day.disabled ? undefined : dayMeta?.get(day.key);
-              const style = cellStyleFor(meta);
+              const adornment = adornmentFor(meta);
               const tooltip = tooltipFor(meta);
-              const sx = style
-                ? {
-                    '& .MuiOutlinedInput-notchedOutline': {
-                      borderColor: style.borderColor,
-                      borderStyle: style.borderStyle,
-                      borderWidth: 2,
-                    },
-                    '&:hover .MuiOutlinedInput-notchedOutline, & .Mui-focused .MuiOutlinedInput-notchedOutline':
-                      {
-                        borderColor: style.borderColor,
-                      },
-                  }
-                : undefined;
+              const endAdornment = adornment ? (
+                <InputAdornment
+                  position="end"
+                  sx={{
+                    fontSize: '0.95rem',
+                    opacity: adornment.opacity,
+                    ml: 0,
+                    mr: -0.5,
+                    pointerEvents: 'none',
+                  }}
+                >
+                  {adornment.icon}
+                </InputAdornment>
+              ) : undefined;
               const field = (
                 <TextField
                   size="small"
@@ -133,7 +120,10 @@ export function PeriodInput({ period, onChange, dayMeta }: PeriodInputProps) {
                     onChange(day.date, parseFloat(ev.target.value || '0'))
                   }
                   type="number"
-                  sx={sx}
+                  slotProps={{
+                    input: { endAdornment },
+                    htmlInput: { style: { paddingRight: 2 } },
+                  }}
                 />
               );
               return (

--- a/workday-application/src/main/react/components/inputs/PeriodInput.tsx
+++ b/workday-application/src/main/react/components/inputs/PeriodInput.tsx
@@ -100,14 +100,23 @@ export function PeriodInput({ period, onChange, dayMeta }: PeriodInputProps) {
                 <InputAdornment
                   position="end"
                   sx={{
-                    fontSize: '0.95rem',
                     opacity: adornment.opacity,
                     ml: 0,
-                    mr: -0.5,
+                    mr: -0.25,
                     pointerEvents: 'none',
                   }}
                 >
-                  {adornment.icon}
+                  <span
+                    style={{
+                      fontSize: '0.66rem',
+                      lineHeight: 1,
+                      display: 'inline-block',
+                      transform: 'scale(0.7)',
+                      transformOrigin: 'center',
+                    }}
+                  >
+                    {adornment.icon}
+                  </span>
                 </InputAdornment>
               ) : undefined;
               const field = (

--- a/workday-application/src/main/react/components/inputs/PeriodInput.tsx
+++ b/workday-application/src/main/react/components/inputs/PeriodInput.tsx
@@ -21,29 +21,26 @@ export type PeriodInputProps = {
 
 type CellStyle = {
   borderColor: string;
-  borderStyle: 'solid' | 'dashed' | 'dotted';
-  background: string;
+  borderStyle: 'solid' | 'dashed';
 };
 
-// Flock-aligned palette: green for hackdays, sun-yellow for leave.
-// Approved leave is solid yellow; requested leave is the same hue but dotted
-// to imply "not yet final".
+// Subtle bottom-border indicators only. Green + purple stays distinct under
+// red-green colourblindness (deuteranopia/protanopia) and on the blue-yellow
+// axis (tritanopia), and avoids the "warning/error" connotation that
+// yellow/orange carries.
 const HACKDAY_STYLE: CellStyle = {
   borderColor: '#2E7D32',
   borderStyle: 'solid',
-  background: 'rgba(46, 125, 50, 0.08)',
 };
 
 const LEAVE_APPROVED_STYLE: CellStyle = {
-  borderColor: '#F5B800',
+  borderColor: '#7E57C2',
   borderStyle: 'solid',
-  background: 'rgba(245, 184, 0, 0.14)',
 };
 
 const LEAVE_REQUESTED_STYLE: CellStyle = {
-  borderColor: '#F5B800',
-  borderStyle: 'dotted',
-  background: 'rgba(245, 184, 0, 0.05)',
+  borderColor: '#7E57C2',
+  borderStyle: 'dashed',
 };
 
 const cellStyleFor = (meta: DayMeta | undefined): CellStyle | undefined => {
@@ -113,18 +110,22 @@ export function PeriodInput({ period, onChange, dayMeta }: PeriodInputProps) {
               const meta = day.disabled ? undefined : dayMeta?.get(day.key);
               const style = cellStyleFor(meta);
               const tooltip = tooltipFor(meta);
+              // Bottom-border-only indicator via a pseudo-element so that
+              // dashed strokes render correctly (boxShadow can't do dashed).
               const sx = style
                 ? {
-                    backgroundColor: style.background,
-                    '& .MuiOutlinedInput-notchedOutline': {
-                      borderColor: style.borderColor,
-                      borderStyle: style.borderStyle,
-                      borderWidth: 2,
+                    '& .MuiOutlinedInput-root': {
+                      position: 'relative',
                     },
-                    '&:hover .MuiOutlinedInput-notchedOutline, & .Mui-focused .MuiOutlinedInput-notchedOutline':
-                      {
-                        borderColor: style.borderColor,
-                      },
+                    '& .MuiOutlinedInput-root::after': {
+                      content: '""',
+                      position: 'absolute',
+                      left: 4,
+                      right: 4,
+                      bottom: -1,
+                      borderBottom: `3px ${style.borderStyle} ${style.borderColor}`,
+                      pointerEvents: 'none',
+                    },
                   }
                 : undefined;
               const field = (

--- a/workday-application/src/main/react/components/inputs/PeriodInput.tsx
+++ b/workday-application/src/main/react/components/inputs/PeriodInput.tsx
@@ -110,22 +110,17 @@ export function PeriodInput({ period, onChange, dayMeta }: PeriodInputProps) {
               const meta = day.disabled ? undefined : dayMeta?.get(day.key);
               const style = cellStyleFor(meta);
               const tooltip = tooltipFor(meta);
-              // Bottom-border-only indicator via a pseudo-element so that
-              // dashed strokes render correctly (boxShadow can't do dashed).
               const sx = style
                 ? {
-                    '& .MuiOutlinedInput-root': {
-                      position: 'relative',
+                    '& .MuiOutlinedInput-notchedOutline': {
+                      borderColor: style.borderColor,
+                      borderStyle: style.borderStyle,
+                      borderWidth: 2,
                     },
-                    '& .MuiOutlinedInput-root::after': {
-                      content: '""',
-                      position: 'absolute',
-                      left: 4,
-                      right: 4,
-                      bottom: -1,
-                      borderBottom: `3px ${style.borderStyle} ${style.borderColor}`,
-                      pointerEvents: 'none',
-                    },
+                    '&:hover .MuiOutlinedInput-notchedOutline, & .Mui-focused .MuiOutlinedInput-notchedOutline':
+                      {
+                        borderColor: style.borderColor,
+                      },
                   }
                 : undefined;
               const field = (

--- a/workday-application/src/main/react/components/inputs/PeriodInput.tsx
+++ b/workday-application/src/main/react/components/inputs/PeriodInput.tsx
@@ -1,4 +1,4 @@
-import { Box, InputAdornment, TextField, Tooltip } from '@mui/material';
+import { Box, TextField, Tooltip } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import dayjs, { type Dayjs } from 'dayjs';
@@ -19,24 +19,16 @@ export type PeriodInputProps = {
   dayMeta?: Map<string, DayMeta>;
 };
 
-type CellAdornment = {
-  icon: string;
-  opacity: number;
-};
+// Background-only fill — green for hackdays, purple for leave (no
+// distinction between requested/approved). Green + purple stays distinct
+// across deuteranopia, protanopia, and tritanopia.
+const HACKDAY_BG = 'rgba(46, 125, 50, 0.16)';
+const LEAVE_BG = 'rgba(126, 87, 194, 0.18)';
 
-const HACKDAY_ICON = '💻';
-const LEAVE_ICON = '🌴';
-
-const adornmentFor = (meta: DayMeta | undefined): CellAdornment | undefined => {
+const backgroundFor = (meta: DayMeta | undefined): string | undefined => {
   if (!meta) return undefined;
-  if (meta.hackday) return { icon: HACKDAY_ICON, opacity: 1 };
-  if (meta.leave) {
-    return {
-      icon: LEAVE_ICON,
-      // Requested leave is rendered dimmer to imply "not yet final".
-      opacity: meta.leave.status === 'REQUESTED' ? 0.45 : 1,
-    };
-  }
+  if (meta.hackday) return HACKDAY_BG;
+  if (meta.leave) return LEAVE_BG;
   return undefined;
 };
 
@@ -94,33 +86,15 @@ export function PeriodInput({ period, onChange, dayMeta }: PeriodInputProps) {
             </Grid>
             {week.days?.map((day) => {
               const meta = day.disabled ? undefined : dayMeta?.get(day.key);
-              const adornment = adornmentFor(meta);
+              const background = backgroundFor(meta);
               const tooltip = tooltipFor(meta);
-              const endAdornment = adornment ? (
-                <InputAdornment
-                  position="end"
-                  sx={{
-                    opacity: adornment.opacity,
-                    ml: 0,
-                    mr: -0.25,
-                    alignSelf: 'flex-end',
-                    marginBottom: '-3px',
-                    pointerEvents: 'none',
-                  }}
-                >
-                  <span
-                    style={{
-                      fontSize: '0.66rem',
-                      lineHeight: 1,
-                      display: 'inline-block',
-                      transform: 'scale(0.84)',
-                      transformOrigin: 'bottom right',
-                    }}
-                  >
-                    {adornment.icon}
-                  </span>
-                </InputAdornment>
-              ) : undefined;
+              const sx = background
+                ? {
+                    '& .MuiOutlinedInput-root': {
+                      backgroundColor: background,
+                    },
+                  }
+                : undefined;
               const field = (
                 <TextField
                   size="small"
@@ -131,10 +105,7 @@ export function PeriodInput({ period, onChange, dayMeta }: PeriodInputProps) {
                     onChange(day.date, parseFloat(ev.target.value || '0'))
                   }
                   type="number"
-                  slotProps={{
-                    input: { endAdornment },
-                    htmlInput: { style: { paddingRight: 2 } },
-                  }}
+                  sx={sx}
                 />
               );
               return (

--- a/workday-application/src/main/react/components/inputs/PeriodInput.tsx
+++ b/workday-application/src/main/react/components/inputs/PeriodInput.tsx
@@ -103,6 +103,8 @@ export function PeriodInput({ period, onChange, dayMeta }: PeriodInputProps) {
                     opacity: adornment.opacity,
                     ml: 0,
                     mr: -0.25,
+                    alignSelf: 'flex-end',
+                    marginBottom: '-3px',
                     pointerEvents: 'none',
                   }}
                 >
@@ -111,8 +113,8 @@ export function PeriodInput({ period, onChange, dayMeta }: PeriodInputProps) {
                       fontSize: '0.66rem',
                       lineHeight: 1,
                       display: 'inline-block',
-                      transform: 'scale(0.7)',
-                      transformOrigin: 'center',
+                      transform: 'scale(0.84)',
+                      transformOrigin: 'bottom right',
                     }}
                   >
                     {adornment.icon}

--- a/workday-application/src/main/react/features/workday/WorkDayForm.tsx
+++ b/workday-application/src/main/react/features/workday/WorkDayForm.tsx
@@ -13,6 +13,7 @@ import { DatePickerField } from '../../components/fields/DatePickerField';
 import { DropzoneAreaField } from '../../components/fields/DropzoneAreaField';
 import { PeriodInputField } from '../../components/fields/PeriodInputField';
 import { StatusSelect } from '../../components/status/StatusSelect';
+import { useDayMeta } from '../../hooks/DayMetaHook';
 import { usePerson } from '../../hooks/PersonHook';
 import { type DatePreset, datePresets } from '../../utils/DatePreset';
 import { isDefined } from '../../utils/validation';
@@ -39,6 +40,19 @@ type WorkDayFormProps = {
   value: any;
   onSubmit?: (data: any) => Promise<void> | void;
 };
+
+function WorkDayPeriodField({
+  from,
+  to,
+  personId,
+}: {
+  from: dayjs.Dayjs;
+  to: dayjs.Dayjs;
+  personId: string | undefined;
+}) {
+  const dayMeta = useDayMeta(personId, from, to);
+  return <PeriodInputField name="days" from={from} to={to} dayMeta={dayMeta} />;
+}
 
 export function WorkDayForm({ value, onSubmit }: WorkDayFormProps) {
   const [person] = usePerson();
@@ -123,7 +137,11 @@ export function WorkDayForm({ value, onSubmit }: WorkDayFormProps) {
             component={TextField}
           />
         ) : (
-          <PeriodInputField name="days" from={values.from} to={values.to} />
+          <WorkDayPeriodField
+            from={values.from}
+            to={values.to}
+            personId={person?.uuid}
+          />
         )}
       </Grid>
     </>

--- a/workday-application/src/main/react/hooks/DayMetaHook.ts
+++ b/workday-application/src/main/react/hooks/DayMetaHook.ts
@@ -1,0 +1,192 @@
+import dayjs, { type Dayjs } from 'dayjs';
+import { useEffect, useState } from 'react';
+import { EventClient, type FlockEvent } from '../clients/EventClient';
+import { LeaveDayClient } from '../clients/LeaveDayClient';
+import { stringifyDate } from '../utils/stringifyDate';
+
+export type LeaveDayStatus = 'REQUESTED' | 'APPROVED' | 'REJECTED' | 'DONE';
+export type LeaveDayType =
+  | 'HOLIDAY'
+  | 'PLUSDAY'
+  | 'PAID_PARENTAL_LEAVE'
+  | 'UNPAID_PARENTAL_LEAVE'
+  | 'PAID_LEAVE';
+
+export type DayMeta = {
+  hackday?: { description: string };
+  leave?: {
+    type: LeaveDayType;
+    status: LeaveDayStatus;
+    description?: string;
+  };
+};
+
+type LeaveDayLite = {
+  from: Dayjs;
+  to: Dayjs;
+  days?: number[];
+  status: LeaveDayStatus;
+  type: LeaveDayType;
+  description?: string;
+};
+
+const LEAVE_DAY_FETCH_SIZE = 200;
+
+const leaveLabel = (type: LeaveDayType): string => {
+  switch (type) {
+    case 'HOLIDAY':
+      return 'Holiday';
+    case 'PLUSDAY':
+      return 'Plusday';
+    case 'PAID_PARENTAL_LEAVE':
+      return 'Paid parental leave';
+    case 'UNPAID_PARENTAL_LEAVE':
+      return 'Unpaid parental leave';
+    case 'PAID_LEAVE':
+      return 'Paid leave';
+  }
+};
+
+const eachDay = (from: Dayjs, to: Dayjs): Dayjs[] => {
+  const days: Dayjs[] = [];
+  let cursor = from.startOf('day');
+  const end = to.startOf('day');
+  while (!cursor.isAfter(end)) {
+    days.push(cursor);
+    cursor = cursor.add(1, 'day');
+  }
+  return days;
+};
+
+const overlapDays = (
+  rangeFrom: Dayjs,
+  rangeTo: Dayjs,
+  itemFrom: Dayjs,
+  itemTo: Dayjs,
+  itemDays?: number[],
+): Dayjs[] => {
+  if (itemTo.isBefore(rangeFrom, 'day') || itemFrom.isAfter(rangeTo, 'day')) {
+    return [];
+  }
+  return eachDay(itemFrom, itemTo).filter((date, index) => {
+    if (itemDays && itemDays[index] != null && itemDays[index] === 0) {
+      return false;
+    }
+    return !date.isBefore(rangeFrom, 'day') && !date.isAfter(rangeTo, 'day');
+  });
+};
+
+const yearsInRange = (from: Dayjs, to: Dayjs): number[] => {
+  const years: number[] = [];
+  for (let year = from.year(); year <= to.year(); year++) {
+    years.push(year);
+  }
+  return years;
+};
+
+export function useDayMeta(
+  personId: string | undefined,
+  from: Dayjs | undefined,
+  to: Dayjs | undefined,
+): Map<string, DayMeta> {
+  const [meta, setMeta] = useState<Map<string, DayMeta>>(() => new Map());
+
+  const fromKey = from ? stringifyDate(from) : '';
+  const toKey = to ? stringifyDate(to) : '';
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: fromKey/toKey are stable string projections of from/to to avoid re-fetching on every render
+  useEffect(() => {
+    if (!personId || !from || !to || from.isAfter(to, 'day')) {
+      setMeta(new Map());
+      return;
+    }
+
+    let cancelled = false;
+
+    const hackdaysPromise = Promise.all(
+      yearsInRange(from, to).map((year) => EventClient.getHackDays(year)),
+    ).then((pages) =>
+      pages
+        .flat()
+        .filter((event: FlockEvent) =>
+          event.persons.some((p) => p.uuid === personId),
+        ),
+    );
+
+    const leavePromise = LeaveDayClient.queryByPage(
+      { page: 0, size: LEAVE_DAY_FETCH_SIZE, sort: 'from,desc' },
+      { personId },
+    ).then((res) => res.list as unknown as LeaveDayLite[]);
+
+    Promise.all([hackdaysPromise, leavePromise])
+      .then(([hackdays, leaveDays]) => {
+        if (cancelled) return;
+
+        const next = new Map<string, DayMeta>();
+
+        for (const event of hackdays) {
+          const dates = overlapDays(from, to, event.from, event.to);
+          for (const date of dates) {
+            const key = stringifyDate(date);
+            const existing = next.get(key) ?? {};
+            next.set(key, {
+              ...existing,
+              hackday: { description: event.description },
+            });
+          }
+        }
+
+        for (const leave of leaveDays) {
+          if (leave.status === 'REJECTED') continue;
+          const dates = overlapDays(
+            from,
+            to,
+            dayjs(leave.from),
+            dayjs(leave.to),
+            leave.days,
+          );
+          for (const date of dates) {
+            const key = stringifyDate(date);
+            const existing = next.get(key) ?? {};
+            const incoming = {
+              type: leave.type,
+              status: leave.status,
+              description: leave.description ?? leaveLabel(leave.type),
+            };
+            // Prefer the more "definitive" status if multiple leave records overlap
+            if (
+              !existing.leave ||
+              statusWeight(incoming.status) >
+                statusWeight(existing.leave.status)
+            ) {
+              next.set(key, { ...existing, leave: incoming });
+            }
+          }
+        }
+
+        setMeta(next);
+      })
+      .catch(() => {
+        if (!cancelled) setMeta(new Map());
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [personId, fromKey, toKey]);
+
+  return meta;
+}
+
+const statusWeight = (status: LeaveDayStatus): number => {
+  switch (status) {
+    case 'DONE':
+      return 3;
+    case 'APPROVED':
+      return 2;
+    case 'REQUESTED':
+      return 1;
+    case 'REJECTED':
+      return 0;
+  }
+};


### PR DESCRIPTION
## Context
When entering hours per day for a customer/project in `WorkDayForm`, there was no signal on the day grid that a given day was already accounted for elsewhere — a hackday the user attends or one of their leave days. It was easy to double-book a customer day on top of a Flock Hack Day or a holiday. This PR adds a soft visual reminder on each affected cell. Inputs stay fully editable on purpose: this is guidance, not a block.

## Before
![before](https://gist.githubusercontent.com/pimfm/bb23e216eaeee677db0b43de10aadcd5/raw/b7aff76fc0d3775801f8d78369a82d67c8c17e9a/workday-soft-warn-before.png)

## After
![after](https://gist.githubusercontent.com/pimfm/bb23e216eaeee677db0b43de10aadcd5/raw/40c4fbefa300ff7eac125e0705b6242a94a83fca/workday-soft-warn.png)

A subtle background fill on each affected cell:

- **Hackdays** get a soft **green** tint — Friday cells in the screenshot.
- **Leave** (any status: requested or approved) gets a soft **purple** tint — week of Mar 23-27, Apr 6-15, May 4-8.

Green + purple stays distinct under deuteranopia, protanopia, and tritanopia. Each marked cell carries a tooltip naming the conflict (e.g. *Holiday — easter break (requested)*); `REJECTED` leave is ignored.

## Changes
- Add soft-warn indicators for hackdays and leave days in WorkDayForm
- Switch soft-warn palette to green hackdays and yellow leave
- Soften soft-warn to bottom-border-only with green + purple
- Use 2px full border for soft-warn (more legible than bottom-only)
- Try icon variant — 💻 hackdays, 🌴 leave, dim for requested
- Shrink soft-warn icons by ~30%
- Anchor soft-warn icons to the bottom of the cell, +20%
- Switch soft-warn to background fill — green hackday, purple leave
