### PR TITLE
Exclude weekends from DayListItem day count

### DIFF
--- a/workday-application/src/develop/kotlin/community/flock/eco/workday/application/mocks/LoadLeaveDayData.kt
+++ b/workday-application/src/develop/kotlin/community/flock/eco/workday/application/mocks/LoadLeaveDayData.kt
@@ -33,6 +33,26 @@ class LoadLeaveDayData(
     }
 
     private fun createHolidays(it: Person) {
+        // Deterministic demo entries that exercise the weekday/calendar-day distinction:
+        //   Fri 2040-04-06 → Fri 2040-04-13 — 8 calendar days, 6 weekdays, 48h (spans a weekend)
+        //   Mon 2040-04-16 → Fri 2040-04-20 — 5 calendar days, 5 weekdays, 40h (no weekend)
+        LeaveDayForm(
+            description = "Demo holiday ${it.firstname} (spans weekend)",
+            from = LocalDate.of(2040, 4, 6),
+            to = LocalDate.of(2040, 4, 13),
+            days = mutableListOf(8.0, 0.0, 0.0, 8.0, 8.0, 8.0, 8.0, 8.0),
+            hours = 48.0,
+            personId = it.uuid,
+        ).create()
+        LeaveDayForm(
+            description = "Demo holiday ${it.firstname} (no weekend)",
+            from = LocalDate.of(2040, 4, 16),
+            to = LocalDate.of(2040, 4, 20),
+            days = mutableListOf(8.0, 8.0, 8.0, 8.0, 8.0),
+            hours = 40.0,
+            personId = it.uuid,
+        ).create()
+
         for (i in 0 until 10) {
             val random = (0..200).random().toLong()
             LeaveDayForm(

--- a/workday-application/src/main/react/components/DayListItem.tsx
+++ b/workday-application/src/main/react/components/DayListItem.tsx
@@ -1,9 +1,22 @@
 import { Card, CardContent, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import UserAuthorityUtil from '@workday-user/user_utils/UserAuthorityUtil';
+import type { Dayjs } from 'dayjs';
 // types
 import type { DayProps } from '../types';
 import { StatusMenu } from './status/StatusMenu';
+
+function countWeekdays(from: Dayjs, to: Dayjs): number {
+  let count = 0;
+  let cursor = from.startOf('day');
+  const end = to.startOf('day');
+  while (!cursor.isAfter(end)) {
+    const day = cursor.day();
+    if (day !== 0 && day !== 6) count++;
+    cursor = cursor.add(1, 'day');
+  }
+  return count;
+}
 
 const PREFIX = 'DayListItem';
 
@@ -49,7 +62,7 @@ export function DayListItem({
           {value.to.format('DD-MM-YYYY')}
         </Typography>
         <Typography>
-          Aantal dagen: {value.to.diff(value.from, 'days') + 1}
+          Aantal dagen: {countWeekdays(value.from, value.to)}
         </Typography>
         <Typography>Aantal uren: {value.hours}</Typography>
         <div className={classes.status}>


### PR DESCRIPTION
## Context
On the Leave days page each leave-request card shows both "Aantal dagen" and "Aantal uren". The hours value already reflects weekdays only, but "Aantal dagen" counted every calendar day in the period including Saturdays and Sundays. That inconsistency made the day count look wrong for any period that spans a weekend. Count Monday–Friday only so the two values line up.

Two deterministic fixtures are added to `LoadLeaveDayData` so a fresh develop seed always has both a weekend-spanning and a weekend-free example to verify the behaviour.

## Before (spans a weekend — Fri 06-04-2040 → Fri 13-04-2040, 48h)
![weekend-before](https://gist.githubusercontent.com/pimfm/61859a33207c5915a382591a7c20c4c7/raw/256998f11bb09131e15d4e090359841544d16643/weekend-before.png)

## After (spans a weekend)
![weekend-after](https://gist.githubusercontent.com/pimfm/61859a33207c5915a382591a7c20c4c7/raw/d6b6b15038670df9a429b858657a1eaa336b403e/weekend-after.png)

Before: 8 calendar days. After: 6 weekdays — matches 48h / 8h.

## Before (no weekend — Mon 16-04-2040 → Fri 20-04-2040, 40h)
![no-weekend-before](https://gist.githubusercontent.com/pimfm/61859a33207c5915a382591a7c20c4c7/raw/ae07bde4f58268d8856b55650572d90c9ba9b01a/no-weekend-before.png)

## After (no weekend)
![no-weekend-after](https://gist.githubusercontent.com/pimfm/61859a33207c5915a382591a7c20c4c7/raw/ae07bde4f58268d8856b55650572d90c9ba9b01a/no-weekend-after.png)

Unchanged at 5 — no weekend in the range, so nothing gets subtracted.

## Changes
- Exclude weekends from DayListItem day count
- Seed deterministic leave-day fixtures for weekday demo
