### PR TITLE
Preselect assignment when user has a single active one

### DIFF
--- a/workday-application/src/main/react/components/selector/AssignmentSelector.tsx
+++ b/workday-application/src/main/react/components/selector/AssignmentSelector.tsx
@@ -9,7 +9,7 @@ import FormHelperText from '@mui/material/FormHelperText';
 import dayjs, { type Dayjs } from 'dayjs';
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   type Assignment,
   AssignmentClient,
@@ -40,6 +40,7 @@ export function AssignmentSelector({
 }: AssignmentSelectorProps) {
   const [items, setItems] = useState<Assignment[]>();
   const [state, setState] = useState(value);
+  const autoSelectedRef = useRef(false);
 
   useEffect(() => {
     if (!personId) return;
@@ -53,13 +54,28 @@ export function AssignmentSelector({
     setState(value);
   }, [value]);
 
-  const assignmentInPeriod = (assignment: Assignment) => {
-    return (
-      assignment.code === value ||
-      (assignment.from.isSameOrBefore(from) &&
-        (!assignment.to || assignment.to.isSameOrAfter(to, 'day')))
-    );
-  };
+  const isActiveInPeriod = useCallback(
+    (assignment: Assignment) =>
+      assignment.from.isSameOrBefore(from) &&
+      (!assignment.to || assignment.to.isSameOrAfter(to, 'day')),
+    [from, to],
+  );
+
+  const assignmentInPeriod = (assignment: Assignment) =>
+    assignment.code === value || isActiveInPeriod(assignment);
+
+  useEffect(() => {
+    if (!items || autoSelectedRef.current) return;
+    if (value) {
+      autoSelectedRef.current = true;
+      return;
+    }
+    const activeInPeriod = items.filter(isActiveInPeriod);
+    if (activeInPeriod.length === 1) {
+      autoSelectedRef.current = true;
+      onChange?.(activeInPeriod[0].code);
+    }
+  }, [items, value, onChange, isActiveInPeriod]);
 
   function handleChange(event) {
     const selected = event.target.value;


### PR DESCRIPTION
## Context
When submitting hours on the Workday dialog, users always had to pick an assignment from the dropdown — even though the vast majority only ever have one active assignment at the current date. 

Now, when the user's assignment list resolves and exactly one of them is active in the selected period (and no value was pre-filled by edit mode), the dropdown auto-selects it. If there are zero or multiple active assignments, or the user later clears the choice, we leave the field as-is.

## Before
![before](https://gist.githubusercontent.com/pimfm/2a52fa457e67ab4d08eb0d4478319fee/raw/dab5b7d22f6faa199bbde2e8a0bf95681d520e1d/workday-dialog-before.png)

## After
![after](https://gist.githubusercontent.com/pimfm/2a52fa457e67ab4d08eb0d4478319fee/raw/a9260ef7268e79eed5f61d9e894ccfc6c85bcc42/workday-dialog-after.png)

## Changes
- Preselect assignment when user has a single active one
