### PR TITLE
Migrate project endpoints to Wirespec handlers

### DIFF
--- a/tests/project.spec.ts
+++ b/tests/project.spec.ts
@@ -1,0 +1,123 @@
+import { expect, test } from '@playwright/test';
+import { Given_I_am_logged_in_as_user } from './steps/workdaySteps';
+
+const PROJECT_URL = '/projects';
+const ADMIN_USERNAME = 'bert';
+
+test.describe('Project CRUD Operations', () => {
+  test.beforeEach(async ({ page }) => {
+    await Given_I_am_logged_in_as_user(page, ADMIN_USERNAME);
+    await page.goto(PROJECT_URL);
+    await page.waitForLoadState('networkidle');
+  });
+
+  async function openCreateDialog(page) {
+    await page.getByRole('button', { name: 'Add' }).click();
+    await expect(page.getByText('Create a project')).toBeVisible();
+  }
+
+  async function openEditDialogFor(page, projectName: string) {
+    const row = page.getByRole('row', { name: new RegExp(projectName) });
+    await row.getByRole('button').last().click();
+    await expect(page.getByText('Create a project')).toBeVisible();
+  }
+
+  test('should display the seeded project list', async ({ page }) => {
+    await expect(page.getByText('Projects')).toBeVisible();
+    await expect(
+      page.getByRole('cell', { name: 'Empty project' }),
+    ).toBeVisible();
+  });
+
+  test('should create a new project', async ({ page }) => {
+    const projectName = `E2E created project ${Date.now()}`;
+
+    await openCreateDialog(page);
+
+    await page.getByLabel('Name').fill(projectName);
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await expect(page.getByText('Create a project')).not.toBeVisible();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByRole('cell', { name: projectName })).toBeVisible();
+  });
+
+  test('should edit an existing project', async ({ page }) => {
+    const originalName = `E2E editable project ${Date.now()}`;
+    const updatedName = `${originalName} (renamed)`;
+
+    // Seed a project we own so the test does not depend on other tests
+    await openCreateDialog(page);
+    await page.getByLabel('Name').fill(originalName);
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(page.getByText('Create a project')).not.toBeVisible();
+    await page.waitForLoadState('networkidle');
+
+    await openEditDialogFor(page, originalName);
+
+    const nameField = page.getByLabel('Name');
+    await nameField.clear();
+    await nameField.fill(updatedName);
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await expect(page.getByText('Create a project')).not.toBeVisible();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByRole('cell', { name: updatedName })).toBeVisible();
+    await expect(
+      page.getByRole('cell', { name: originalName, exact: true }),
+    ).toHaveCount(0);
+  });
+
+  test('should delete a project without assignments', async ({ page }) => {
+    const projectName = `E2E deletable project ${Date.now()}`;
+
+    // Seed a fresh project (no assignments => delete is enabled)
+    await openCreateDialog(page);
+    await page.getByLabel('Name').fill(projectName);
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(page.getByText('Create a project')).not.toBeVisible();
+    await page.waitForLoadState('networkidle');
+
+    await openEditDialogFor(page, projectName);
+
+    // The Delete button is only visible when there are no assignments
+    await page.getByRole('button', { name: 'Delete' }).click();
+
+    await expect(page.getByText('Create a project')).not.toBeVisible();
+    await page.waitForLoadState('networkidle');
+
+    await expect(
+      page.getByRole('cell', { name: projectName, exact: true }),
+    ).toHaveCount(0);
+  });
+
+  test('should disable delete for a project that has assignments', async ({
+    page,
+  }) => {
+    // "Project D" is seeded with assignments via LoadAssignmentData
+    await openEditDialogFor(page, 'Project D');
+
+    await expect(page.getByRole('button', { name: 'Delete' })).toHaveCount(0);
+    await expect(
+      page.getByText(
+        'This project cannot be deleted because it contains assignments',
+      ),
+    ).toBeVisible();
+  });
+
+  test('should cancel creating a project', async ({ page }) => {
+    const projectName = `Should not be saved ${Date.now()}`;
+
+    await openCreateDialog(page);
+    await page.getByLabel('Name').fill(projectName);
+
+    await page.getByRole('button', { name: 'Cancel' }).click();
+
+    await expect(page.getByText('Create a project')).not.toBeVisible();
+    await expect(
+      page.getByRole('cell', { name: projectName, exact: true }),
+    ).toHaveCount(0);
+  });
+});

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/ProjectController.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/ProjectController.kt
@@ -1,50 +1,94 @@
 package community.flock.eco.workday.application.controllers
 
+import community.flock.eco.workday.api.endpoint.DeleteProject
+import community.flock.eco.workday.api.endpoint.GetProjectAll
+import community.flock.eco.workday.api.endpoint.GetProjectByCode
+import community.flock.eco.workday.api.endpoint.PostProject
+import community.flock.eco.workday.api.endpoint.PutProject
 import community.flock.eco.workday.application.forms.ProjectForm
 import community.flock.eco.workday.application.services.ProjectService
-import community.flock.eco.workday.core.utils.toResponse
-import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import community.flock.eco.workday.api.model.Project as ProjectApi
+import community.flock.eco.workday.api.model.ProjectForm as ProjectFormApi
+import community.flock.eco.workday.application.model.Project as ProjectInternal
 
 @RestController
-@RequestMapping("api/projects")
 class ProjectController(
     private val projectService: ProjectService,
-) {
-    @GetMapping
+) : GetProjectAll.Handler,
+    GetProjectByCode.Handler,
+    PostProject.Handler,
+    PutProject.Handler,
+    DeleteProject.Handler {
     @PreAuthorize("hasAuthority('ProjectAuthority.READ')")
-    fun findAll(pageable: Pageable) = projectService.findAll(pageable).toResponse()
+    override suspend fun getProjectAll(request: GetProjectAll.Request): GetProjectAll.Response<*> {
+        val page = PageRequest.of(
+            request.queries.page ?: 0,
+            request.queries.size ?: 20,
+            request.queries.sort?.toSort() ?: Sort.unsorted(),
+        )
+        return GetProjectAll.Response200(
+            projectService
+                .findAll(page)
+                .content
+                .map { it.externalize() },
+        )
+    }
 
-    @GetMapping("{code}")
     @PreAuthorize("hasAuthority('ProjectAuthority.WRITE')")
-    fun findByCode(
-        @PathVariable code: String,
-    ) = projectService.findByCode(code).toResponse()
+    override suspend fun getProjectByCode(request: GetProjectByCode.Request): GetProjectByCode.Response<*> {
+        val project =
+            projectService.findByCode(request.path.code)
+                ?: error("Project with code ${request.path.code} not found")
+        return GetProjectByCode.Response200(project.externalize())
+    }
 
-    @DeleteMapping("{code}")
     @PreAuthorize("hasAuthority('ProjectAuthority.WRITE')")
-    fun delete(
-        @PathVariable code: String,
-    ) = projectService.deleteByCode(code).toResponse()
+    override suspend fun postProject(request: PostProject.Request): PostProject.Response<*> {
+        val project = projectService.create(request.body.internalize())
+        return PostProject.Response200(project.externalize())
+    }
 
-    @PutMapping("{code}")
     @PreAuthorize("hasAuthority('ProjectAuthority.WRITE')")
-    fun update(
-        @PathVariable code: String,
-        @RequestBody form: ProjectForm,
-    ) = projectService.update(code, form).toResponse()
+    override suspend fun putProject(request: PutProject.Request): PutProject.Response<*> {
+        val project = projectService.update(request.path.code, request.body.internalize())
+        return PutProject.Response200(project.externalize())
+    }
 
-    @PostMapping
     @PreAuthorize("hasAuthority('ProjectAuthority.WRITE')")
-    fun create(
-        @RequestBody form: ProjectForm,
-    ) = projectService.create(form)
+    override suspend fun deleteProject(request: DeleteProject.Request): DeleteProject.Response<*> {
+        projectService.deleteByCode(request.path.code)
+        return DeleteProject.Response200(Unit)
+    }
+
+    private fun ProjectInternal.externalize() =
+        ProjectApi(
+            id = id,
+            code = code,
+            name = name,
+        )
+
+    private fun ProjectFormApi.internalize() =
+        ProjectForm(
+            name = name ?: "",
+        )
+
+    private fun String.toSort(): Sort =
+        split(",")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .let { parts ->
+                when {
+                    parts.isEmpty() -> Sort.unsorted()
+                    parts.size == 1 -> Sort.by(parts[0])
+                    parts.last().equals("asc", ignoreCase = true) ->
+                        Sort.by(Sort.Direction.ASC, *parts.dropLast(1).toTypedArray())
+                    parts.last().equals("desc", ignoreCase = true) ->
+                        Sort.by(Sort.Direction.DESC, *parts.dropLast(1).toTypedArray())
+                    else -> Sort.by(*parts.toTypedArray())
+                }
+            }
 }

--- a/workday-application/src/main/wirespec/projects.ws
+++ b/workday-application/src/main/wirespec/projects.ws
@@ -1,17 +1,17 @@
-endpoint FindByCode_2 GET /api/projects/{code: String} -> {
-  200 -> Project
-}
-endpoint Update PUT ProjectForm /api/projects/{code: String} -> {
-  200 -> Project
-}
-endpoint Delete_2 DELETE /api/projects/{code: String} -> {
-  200 -> Unit
-}
-endpoint FindAll GET /api/projects ? {pageable: Pageable} -> {
+endpoint GetProjectAll GET /api/projects ? {page: Integer32?, size: Integer32?, sort: String?} -> {
   200 -> Project[]
 }
-endpoint Create POST ProjectForm /api/projects -> {
+endpoint GetProjectByCode GET /api/projects/{code: String} -> {
   200 -> Project
+}
+endpoint PostProject POST ProjectForm /api/projects -> {
+  200 -> Project
+}
+endpoint PutProject PUT ProjectForm /api/projects/{code: String} -> {
+  200 -> Project
+}
+endpoint DeleteProject DELETE /api/projects/{code: String} -> {
+  200 -> Unit
 }
 
 type ProjectForm {


### PR DESCRIPTION
## Summary
- Renamed `projects.ws` endpoints to descriptive names (`GetProjectAll`, `GetProjectByCode`, `PostProject`, `PutProject`, `DeleteProject`).
- Rewrote `ProjectController` to implement the generated Wirespec handler interfaces, following the recent `ClientController` refactor (#466).
- Used individual `page`/`size`/`sort` query params on `GetProjectAll` (instead of a Wirespec `Pageable` object) so the wire format stays compatible with the React `PageableClient`.

## Test plan
- [x] `./mvnw -pl workday-application -am clean compile` passes.
- [ ] CI green on this PR.
- [ ] Manual smoke test: project list, create, update, delete via the UI still works.

https://claude.ai/code/session_019CezYfvL65RGJNBjjbdWfd

---
_Generated by [Claude Code](https://claude.ai/code/session_019CezYfvL65RGJNBjjbdWfd)_