### PR TITLE
Add total count header to GetAssignmentAll response

### DIFF
--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/AssignmentController.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/AssignmentController.kt
@@ -46,24 +46,26 @@ class AssignmentController(
     override suspend fun getAssignmentAll(request: GetAssignmentAll.Request): GetAssignmentAll.Response<*> {
         val user = requireAuthority(AssignmentAuthority.READ)
         val q = request.queries
-        val page = q.toPageable()
+        val pageable = q.toPageable()
 
         val to = q.to?.let(LocalDate::parse)
         val personId = q.personId?.let(UUID::fromString)
         val isAdmin = user.hasAuthority(AssignmentAuthority.ADMIN)
 
-        val assignments: List<Assignment> =
+        val page =
             when {
-                to != null -> assignmentService.findAllByToAfterOrToNull(to, page).content
-                isAdmin && personId != null -> assignmentService.findAllByPersonUuid(personId, page).content
-                isAdmin && q.projectCode != null -> assignmentService.findByProjectCode(q.projectCode, page).content
-                else -> assignmentService.findAllByPersonUserCode(user.code, page).content
+                to != null -> assignmentService.findAllByToAfterOrToNull(to, pageable)
+                isAdmin && personId != null -> assignmentService.findAllByPersonUuid(personId, pageable)
+                isAdmin && q.projectCode != null -> assignmentService.findByProjectCode(q.projectCode, pageable)
+                else -> assignmentService.findAllByPersonUserCode(user.code, pageable)
             }
 
         return GetAssignmentAll.Response200(
-            assignments
-                .map { it.applyHourlyRate(isAdmin) }
-                .map { it.externalize(includeHours = to == null) },
+            body =
+                page.content
+                    .map { it.applyHourlyRate(isAdmin) }
+                    .map { it.externalize(includeHours = to == null) },
+            xtotal = page.totalElements.toInt(),
         )
     }
 

--- a/workday-application/src/main/wirespec/assignments.ws
+++ b/workday-application/src/main/wirespec/assignments.ws
@@ -1,5 +1,5 @@
 endpoint GetAssignmentAll GET /api/assignments ? {personId: String?, projectCode: String?, to: String?, page: Integer32?, size: Integer32?, sort: String?} -> {
-  200 -> Assignment[]
+  200 -> Assignment[] # { `x-total`: Integer32 }
 }
 endpoint GetAssignmentByCode GET /api/assignments/{code: String} -> {
   200 -> Assignment


### PR DESCRIPTION
## Summary
Updated the GetAssignmentAll endpoint to return the total count of assignments via an `x-total` response header, enabling clients to know the total number of available records when using pagination.

## Key Changes
- Modified `AssignmentController.getAssignmentAll()` to return the full `Page` object instead of just extracting `.content`
- Renamed `page` variable to `pageable` for clarity (represents the pagination request parameters)
- Updated the response to include `xtotal` field set to `page.totalElements.toInt()`, which will be serialized as the `x-total` header
- Updated the WireSpec definition to document the `x-total` header in the 200 response

## Implementation Details
- The service methods already return `Page` objects with pagination metadata; we now utilize the `totalElements` property
- The response body still contains only the current page's assignment content, with the total count provided separately via the header
- This allows clients to implement proper pagination UI/logic by knowing both the current page size and total available records

https://claude.ai/code/session_01FFZUJDexuR1gvJsVqibmv9