### PR TITLE
Fix contract form label overlap on edit

### DIFF
--- a/workday-application/src/main/react/features/contract/ContractFormExternal.tsx
+++ b/workday-application/src/main/react/features/contract/ContractFormExternal.tsx
@@ -26,6 +26,7 @@ export const ContractFormExternal = ({
             label="Hourly rate"
             fullWidth
             component={TextField}
+            slotProps={{ inputLabel: { shrink: true } }}
           />
         </Grid>
         <Grid size={{ xs: 12 }}>
@@ -35,6 +36,7 @@ export const ContractFormExternal = ({
             label="Hours per week"
             fullWidth
             component={TextField}
+            slotProps={{ inputLabel: { shrink: true } }}
           />
         </Grid>
         <Grid size={{ xs: 6 }}>

--- a/workday-application/src/main/react/features/contract/ContractFormInternal.tsx
+++ b/workday-application/src/main/react/features/contract/ContractFormInternal.tsx
@@ -26,6 +26,7 @@ export const ContractFormInternal = ({
             label="Monthly salary"
             fullWidth
             component={TextField}
+            slotProps={{ inputLabel: { shrink: true } }}
           />
         </Grid>
         <Grid size={{ xs: 12 }}>
@@ -35,6 +36,7 @@ export const ContractFormInternal = ({
             label="Hours per week"
             fullWidth
             component={TextField}
+            slotProps={{ inputLabel: { shrink: true } }}
           />
         </Grid>
         <Grid size={{ xs: 6 }}>
@@ -61,6 +63,7 @@ export const ContractFormInternal = ({
             type="number"
             label="Holiday hours"
             component={TextField}
+            slotProps={{ inputLabel: { shrink: true } }}
           />
         </Grid>
         <Grid size={{ xs: 12 }}>
@@ -70,6 +73,7 @@ export const ContractFormInternal = ({
             label="Hack hours"
             fullWidth
             component={TextField}
+            slotProps={{ inputLabel: { shrink: true } }}
           />
         </Grid>
       </Grid>

--- a/workday-application/src/main/react/features/contract/ContractFormManagement.tsx
+++ b/workday-application/src/main/react/features/contract/ContractFormManagement.tsx
@@ -28,6 +28,7 @@ export const ContractFormManagement = ({
             label="Monthly fee"
             fullWidth
             component={TextField}
+            slotProps={{ inputLabel: { shrink: true } }}
           />
         </Grid>
         <Grid size={{ xs: 6 }}>

--- a/workday-application/src/main/react/features/contract/ContractFormService.tsx
+++ b/workday-application/src/main/react/features/contract/ContractFormService.tsx
@@ -27,6 +27,7 @@ export const ContractFormService = ({
             label="Monthly costs"
             fullWidth
             component={TextField}
+            slotProps={{ inputLabel: { shrink: true } }}
           />
         </Grid>
         <Grid size={{ xs: 12 }}>
@@ -36,6 +37,7 @@ export const ContractFormService = ({
             label="Description"
             fullWidth
             component={TextField}
+            slotProps={{ inputLabel: { shrink: true } }}
           />
         </Grid>
         <Grid size={{ xs: 6 }}>


### PR DESCRIPTION
After the MUI v7 migration, formik-mui's TextField no longer shrinks the
floating label when the field has a value, so the value rendered on top
of the label (e.g. "4000hly salary"). Force the input label to shrink
on the numeric/text fields in all four contract forms, which always have
either a saved value or a schema default.