### PR TITLE
Fix broken pagination in /api/contracts

### DIFF
--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/ContractController.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/ContractController.kt
@@ -73,31 +73,39 @@ class ContractController(
         val end = q.end?.let(LocalDate::parse)
         val personId = q.personId?.let(UUID::fromString)
 
-        val contracts: List<Contract> =
+        val (contracts, total) =
             when {
                 personId != null -> {
                     val user = requireAuthority(ContractAuthority.READ)
-                    if (user.hasAuthority(ContractAuthority.ADMIN)) {
-                        contractService.findAllByPersonUuid(personId, pageable).content
-                    } else {
-                        contractService.findAllByPersonUserCode(user.code, pageable).content
-                    }
+                    val page =
+                        if (user.hasAuthority(ContractAuthority.ADMIN)) {
+                            contractService.findAllByPersonUuid(personId, pageable)
+                        } else {
+                            contractService.findAllByPersonUserCode(user.code, pageable)
+                        }
+                    page.content to page.totalElements
                 }
                 to != null -> {
                     requireAuthority(ContractAuthority.ADMIN)
-                    contractService.findAllByToAfterOrToNull(to, pageable).content
+                    val page = contractService.findAllByToAfterOrToNull(to, pageable)
+                    page.content to page.totalElements
                 }
                 start != null || end != null -> {
                     requireAuthority(ContractAuthority.ADMIN)
-                    contractService.findAllByToBetween(start, end).sortedByDescending { it.to }
+                    val list = contractService.findAllByToBetween(start, end).sortedByDescending { it.to }
+                    list to list.size.toLong()
                 }
                 else -> {
                     requireAuthority(ContractAuthority.ADMIN)
-                    contractService.findAll(pageable).content.sortedBy { it.to }
+                    val page = contractService.findAll(pageable)
+                    page.content to page.totalElements
                 }
             }
 
-        return GetContractAll.Response200(contracts.map { it.externalize() })
+        return GetContractAll.Response200(
+            body = contracts.map { it.externalize() },
+            xtotal = total.toInt(),
+        )
     }
 
     @PreAuthorize("hasAuthority('ContractAuthority.READ')")
@@ -334,7 +342,24 @@ class ContractController(
         )
 
     private fun GetContractAll.Queries.toPageable(): Pageable {
-        val sortOrder = sort?.takeIf { it.isNotBlank() }?.let { Sort.by(it) } ?: Sort.unsorted()
+        val sortOrder = sort?.takeIf { it.isNotBlank() }?.let(::parseSort) ?: Sort.unsorted()
         return PageRequest.of(page ?: 0, size ?: 20, sortOrder)
     }
+
+    private fun parseSort(spec: String): Sort =
+        spec
+            .split(",")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .let { parts ->
+                when {
+                    parts.isEmpty() -> Sort.unsorted()
+                    parts.size == 1 -> Sort.by(parts[0])
+                    parts.last().equals("asc", ignoreCase = true) ->
+                        Sort.by(Sort.Direction.ASC, *parts.dropLast(1).toTypedArray())
+                    parts.last().equals("desc", ignoreCase = true) ->
+                        Sort.by(Sort.Direction.DESC, *parts.dropLast(1).toTypedArray())
+                    else -> Sort.by(*parts.toTypedArray())
+                }
+            }
 }

--- a/workday-application/src/main/wirespec/contracts.ws
+++ b/workday-application/src/main/wirespec/contracts.ws
@@ -1,5 +1,5 @@
 endpoint GetContractAll GET /api/contracts ? {personId: String?, to: String?, start: String?, end: String?, page: Integer32?, size: Integer32?, sort: String?} -> {
-  200 -> Contract[]
+  200 -> Contract[] # { `x-total`: Integer32 }
 }
 endpoint GetContractByCode GET /api/contracts/{code: String} -> {
   200 -> Contract

--- a/workday-application/src/test/kotlin/community/flock/eco/workday/controllers/ContractControllerTest.kt
+++ b/workday-application/src/test/kotlin/community/flock/eco/workday/controllers/ContractControllerTest.kt
@@ -21,6 +21,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.LocalDate
@@ -344,6 +345,31 @@ class ContractControllerTest(
             .andExpect(content().contentType(APPLICATION_JSON))
             .andExpect(jsonPath("$.length()").value(1))
             .andExpect(jsonPath("$[0].person.uuid").value(person.uuid.toString()))
+    }
+
+    @Test
+    fun `paged list returns the total count in the x-total header`() {
+        val adminUser = createHelper.createUserEntity(adminAuthorities)
+        val person = createHelper.createPersonEntity()
+        repeat(3) { idx ->
+            createHelper.createContractInternal(
+                person = person,
+                from = LocalDate.of(2024, idx + 1, 1),
+                to = LocalDate.of(2024, idx + 1, 28),
+            )
+        }
+
+        // page=0, size=2: 2 items on the page, but x-total reflects the full match count
+        mvc
+            .perform(
+                get("$baseUrl?personId=${person.uuid}&page=0&size=2&sort=from,desc")
+                    .with(user(CreateHelper.UserSecurity(adminUser.toDomain())))
+                    .accept(APPLICATION_JSON),
+            ).asyncDispatch()
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(APPLICATION_JSON))
+            .andExpect(jsonPath("$.length()").value(2))
+            .andExpect(header().string("x-total", "3"))
     }
 
     @Test


### PR DESCRIPTION
## What was broken

The frontend `PageableClient` (`workday-core/.../PageableClient.ts`) reads the `x-total` HTTP header to know how many total records exist so it can compute the page count. `GetContractAll` was the only paginated list endpoint that didn't emit that header — every comparable endpoint (`assignments`, `sickdays`, `leave-days`, `workdays`, `persons`, `events`, …) declares `# { ` + "`x-total`" + `: Integer32 }` in its Wirespec and passes `xtotal = page.totalElements.toInt()` from its controller. Without it the frontend always saw `count: 0`, so contract lists were stuck on page 1.

Two secondary bugs in the same handler were fixed at the same time:

- `Sort.by(it)` treated the `"from,desc"` value the frontend sends (`ContractClient.findAllByPersonId`) as a single property name, which Spring couldn't resolve.
- The no-filter branch did `.findAll(pageable).content.sortedBy { it.to }` — re-sorting one page in memory after the DB had already applied the user's sort, silently overriding whatever order the caller asked for.

## The fix

- **`workday-application/src/main/wirespec/contracts.ws`** — declare the `x-total` header on the 200 response so Wirespec regenerates `Response200(body, xtotal)`.
- **`ContractController.kt`** — every branch now yields both content and a total count; the response passes `xtotal = total.toInt()`. Added a `parseSort` helper (matching `PersonController`) that handles `field,asc|desc`. Removed the in-memory re-sort that overrode the user's sort. For the unpaged `start`/`end` branch, `x-total` falls back to the list size.
- **`ContractControllerTest.kt`** — new test seeds 3 contracts, requests `page=0&size=2`, and asserts the response body has 2 items with `x-total: 3` so this regression can't sneak back.

https://claude.ai/code/session_01FGFwqiJfc141B621RkTQ9G

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGFwqiJfc141B621RkTQ9G)_