### PR TITLE
Restore type-specific fields on GET /api/contracts responses

### DIFF
--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/ContractController.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/ContractController.kt
@@ -220,6 +220,25 @@ class ContractController(
             to = to?.toString(),
             person = person?.externalize(),
             type = type.externalize(),
+            monthlySalary = (this as? ContractInternal)?.monthlySalary,
+            hoursPerWeek =
+                when (this) {
+                    is ContractInternal -> hoursPerWeek
+                    is ContractExternal -> hoursPerWeek
+                    else -> null
+                },
+            holidayHours = (this as? ContractInternal)?.holidayHours,
+            hackHours = (this as? ContractInternal)?.hackHours,
+            hourlyRate = (this as? ContractExternal)?.hourlyRate,
+            monthlyFee = (this as? ContractManagement)?.monthlyFee,
+            monthlyCosts = (this as? ContractService)?.monthlyCosts,
+            description = (this as? ContractService)?.description,
+            billable =
+                when (this) {
+                    is ContractInternal -> billable
+                    is ContractExternal -> billable
+                    else -> null
+                },
         )
 
     private fun ContractInternal.externalize(): ContractInternalApi =

--- a/workday-application/src/main/wirespec/contracts.ws
+++ b/workday-application/src/main/wirespec/contracts.ws
@@ -38,7 +38,16 @@ type Contract {
   from: String?,
   to: String?,
   person: Person?,
-  `type`: ContractType?
+  `type`: ContractType?,
+  monthlySalary: Number?,
+  hoursPerWeek: Integer32?,
+  holidayHours: Integer32?,
+  hackHours: Integer32?,
+  hourlyRate: Number?,
+  monthlyFee: Number?,
+  monthlyCosts: Number?,
+  description: String?,
+  billable: Boolean?
 }
 enum ContractType {
   INTERNAL, EXTERNAL, MANAGEMENT, SERVICE


### PR DESCRIPTION
After the Wirespec migration in #475, GET /api/contracts/{code} and the
list endpoints lost the type-specific fields (monthlySalary, hourlyRate,
hoursPerWeek, etc.). The handler downcasts to Contract and the static
externalize() extension on the supertype only emits the base fields, so
the ContractDialog form opens with empty inputs and the ContractList
cards show "undefined" for the rate/salary.

Extend the Wirespec Contract type with the optional type-specific
fields shared by the four subtypes and dispatch on the runtime subtype
in Contract.externalize() so each one is populated. Forms (POST/PUT)
keep their typed responses, so the request/response contract for
writes is unchanged.

https://claude.ai/code/session_016cLuzDPn9eTjdUVyEGktRx