### PR TITLE
Show associated user when editing a person

### DIFF
--- a/tests/person.spec.ts
+++ b/tests/person.spec.ts
@@ -151,6 +151,32 @@ test.describe('Person flow', () => {
     await expect(page.getByText(updatedEmail)).toBeVisible();
   });
 
+  test('shows the associated user in the form when editing a person', async ({
+    page,
+  }) => {
+    // The seeded worker "Tommy Dog" is linked to the seeded "Tommy" user
+    // (see the mock LoadPersonData / Users data). Opening the edit dialog must
+    // pre-populate the user selector with that user.
+    const linked = {
+      firstname: 'Tommy',
+      lastname: 'Dog',
+      email: 'tommy@sesam.straat',
+      number: '',
+    };
+    await openPersonDetails(page, linked);
+
+    await page.locator(EDIT_BUTTON).first().click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(page.getByText('Create Person')).toBeVisible();
+
+    // The user selector renders the linked user as "<name> <<email>>". The
+    // email only appears as visible text inside the selector (the email field
+    // is an <input>, whose value getByText does not match), so this asserts
+    // the associated user is shown rather than an empty "None" selector.
+    await expect(dialog.getByText(linked.email).first()).toBeVisible();
+  });
+
   test('deletes a person via the confirmation dialog', async ({ page }) => {
     const data = buildPersonData('Delete');
     await createPerson(page, data);

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/PersonController.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/PersonController.kt
@@ -29,6 +29,7 @@ import community.flock.eco.workday.api.model.Person as PersonApi
 import community.flock.eco.workday.api.model.PersonEvent as PersonEventApi
 import community.flock.eco.workday.api.model.PersonEventEventType as PersonEventEventTypeApi
 import community.flock.eco.workday.api.model.PersonForm as PersonFormApi
+import community.flock.eco.workday.api.model.User as UserApi
 
 @RestController
 class PersonController(
@@ -180,8 +181,18 @@ class PersonController(
             shoeSize = shoeSize,
             shirtSize = shirtSize,
             googleDriveId = googleDriveId,
-            user = null,
+            user = user?.externalize(),
             fullName = "$firstname $lastname",
+        )
+
+    private fun User.externalize(): UserApi =
+        UserApi(
+            id = code,
+            name = name,
+            email = email,
+            authorities = authorities.toList(),
+            accounts = null,
+            created = created.toString(),
         )
 
     private fun PersonEvent.externalize(): PersonEventApi =

--- a/workday-application/src/main/react/clients/PersonClient.ts
+++ b/workday-application/src/main/react/clients/PersonClient.ts
@@ -1,3 +1,4 @@
+import type { User } from '@workday-user/user/response/user';
 import dayjs, { type Dayjs } from 'dayjs';
 import InternalizingClient from '../utils/InternalizingClient';
 import { ISO_8601_DATE } from './util/DateFormats';
@@ -13,7 +14,7 @@ export type Person = {
   birthdate: Dayjs | null;
   joinDate: Dayjs | null;
   position: string;
-  user: string;
+  user: User | null;
   active: boolean;
   lastActiveAt: Date;
   shoeSize?: string;
@@ -41,7 +42,7 @@ export type PersonRaw = {
   birthdate: string;
   joinDate: string;
   position: string;
-  user: string;
+  user: User | null;
   active: boolean;
   lastActiveAt: string;
   shoeSize?: string;

--- a/workday-application/src/main/react/features/person/PersonForm.tsx
+++ b/workday-application/src/main/react/features/person/PersonForm.tsx
@@ -141,7 +141,7 @@ export function PersonForm({ item, onSubmit }: PersonFormProps) {
         ...PERSON_FORM_SCHEMA.cast(),
         active: true,
         ...item,
-        userCode: item?.user?.code,
+        userCode: item?.user?.id,
       }}
       onSubmit={onSubmit}
       validationSchema={PERSON_FORM_SCHEMA}

--- a/workday-application/src/main/react/features/person/schema.ts
+++ b/workday-application/src/main/react/features/person/schema.ts
@@ -19,11 +19,9 @@ const PERSON_SCHEMA = object(_defaultObject)
   })
   .from('userCode', 'user', false);
 
-const PERSON_FORM_SCHEMA = object(_defaultObject)
-  .shape({
-    userCode: string().transform((value) => (value === null ? '' : value)),
-  })
-  .from('user', 'userCode', false);
+const PERSON_FORM_SCHEMA = object(_defaultObject).shape({
+  userCode: string().transform((value) => (value === null ? '' : value)),
+});
 
 const toPerson = async (personForm) => {
   const isPersonForm = await PERSON_FORM_SCHEMA.isValid(personForm);


### PR DESCRIPTION
The person endpoint hardcoded user = null in the response, so the user
selector was never pre-populated when editing a person. Serialize the
associated user (mapping its code to the API id) and read user.id on the
form, matching the value the user selector uses.

https://claude.ai/code/session_016Yvy2n8vncGm6nuB7Z7NCL