### PR TITLE
Allow admins to view and delete user accounts

### DIFF
--- a/tests/userAccounts.spec.ts
+++ b/tests/userAccounts.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/test';
+import { Given_I_am_logged_in_as_user } from './steps/workdaySteps';
+
+// Exercises the admin-only user-account management added to the user edit
+// dialog: an admin opens a user, sees that user's linked login accounts and
+// deletes one. The backend gates DELETE /api/user-accounts/{id} on
+// UserAuthority.WRITE, which the seeded admin (bert) holds.
+//
+// A throwaway user is registered per run so the test never deletes a seeded
+// user's login account — other specs log in as those users.
+test.describe('User account management', () => {
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+  });
+
+  test.afterEach(async ({ page, context }) => {
+    await context.clearCookies();
+    await page.evaluate(() => {
+      if (typeof window.localStorage !== 'undefined')
+        window.localStorage.clear();
+      if (typeof window.sessionStorage !== 'undefined')
+        window.sessionStorage.clear();
+    });
+  });
+
+  test('admin can view and delete a user account', async ({ page }) => {
+    const unique = `e2eaccdel${Date.now()}`;
+    const email = `${unique}@example.com`;
+
+    // bert is seeded as ADMIN and therefore holds UserAuthority.WRITE.
+    await Given_I_am_logged_in_as_user(page, 'bert');
+
+    // Seed a throwaway user with a password account. page.request shares the
+    // logged-in session cookie and CSRF is disabled on the server.
+    const res = await page.request.post('/api/users/register', {
+      data: { email, name: unique, password: 'secret123', authorities: [] },
+    });
+    expect(res.ok()).toBeTruthy();
+
+    // Locate the new user in the list.
+    await page.goto('/users');
+    await page.getByLabel('search').fill(unique);
+
+    const row = page.locator('table tbody tr', { hasText: unique });
+    await expect(row).toBeVisible();
+    await row.click();
+
+    // The edit dialog lists the user's linked accounts.
+    const userDialog = page
+      .getByRole('dialog')
+      .filter({ hasText: 'Create user' });
+    await expect(userDialog.getByText('Accounts')).toBeVisible();
+    await expect(
+      userDialog.getByText('Password', { exact: true }),
+    ).toBeVisible();
+
+    // Delete the password account and confirm.
+    await userDialog.getByRole('button', { name: 'delete account' }).click();
+    await page.getByRole('button', { name: 'Confirm', exact: true }).click();
+
+    // The account is removed.
+    await expect(userDialog.getByText('No accounts')).toBeVisible();
+    await expect(userDialog.getByText('Password', { exact: true })).toHaveCount(
+      0,
+    );
+  });
+});

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/UserAccountApiController.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/UserAccountApiController.kt
@@ -1,5 +1,6 @@
 package community.flock.eco.workday.application.controllers
 
+import community.flock.eco.workday.api.endpoint.DeleteUserAccountById
 import community.flock.eco.workday.api.endpoint.GetUserAccountAll
 import community.flock.eco.workday.api.endpoint.PostUserAccountGenerateKey
 import community.flock.eco.workday.api.endpoint.PostUserAccountRevokeKey
@@ -27,7 +28,8 @@ class UserAccountApiController(
     PutUserAccountResetPassword.Handler,
     PutUserAccountNewPassword.Handler,
     PostUserAccountGenerateKey.Handler,
-    PostUserAccountRevokeKey.Handler {
+    PostUserAccountRevokeKey.Handler,
+    DeleteUserAccountById.Handler {
     private fun authenticationName(): String = SecurityContextHolder.getContext().authentication.name
 
     @PreAuthorize("hasAuthority('UserAuthority.READ')")
@@ -43,6 +45,15 @@ class UserAccountApiController(
             body = page.map { it.externalize() }.toList(),
             xtotal = page.totalElements.toInt(),
         )
+    }
+
+    @PreAuthorize("hasAuthority('UserAuthority.WRITE')")
+    override suspend fun deleteUserAccountById(request: DeleteUserAccountById.Request): DeleteUserAccountById.Response<*> {
+        val id = request.path.id.toLong()
+        if (userAccountRepository.existsById(id)) {
+            userAccountRepository.deleteById(id)
+        }
+        return DeleteUserAccountById.Response200(Unit)
     }
 
     override suspend fun putUserAccountResetPassword(

--- a/workday-application/src/main/wirespec/user-accounts.ws
+++ b/workday-application/src/main/wirespec/user-accounts.ws
@@ -13,6 +13,9 @@ endpoint PostUserAccountGenerateKey POST UserKeyForm /api/user-accounts/generate
 endpoint PostUserAccountRevokeKey POST KeyRevokeForm /api/user-accounts/revoke-key -> {
   200 -> Unit
 }
+endpoint DeleteUserAccountById DELETE /api/user-accounts/{id: String} -> {
+  200 -> Unit
+}
 
 type PasswordResetForm {
   resetCode: String,

--- a/workday-application/src/test/kotlin/community/flock/eco/workday/controllers/UserAccountControllerTest.kt
+++ b/workday-application/src/test/kotlin/community/flock/eco/workday/controllers/UserAccountControllerTest.kt
@@ -1,0 +1,72 @@
+package community.flock.eco.workday.controllers
+
+import community.flock.eco.workday.WorkdayIntegrationTest
+import community.flock.eco.workday.helpers.CreateHelper
+import community.flock.eco.workday.user.authorities.UserAuthority
+import community.flock.eco.workday.user.repositories.UserAccountRepository
+import community.flock.eco.workday.user.services.UserAccountService
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+class UserAccountControllerTest : WorkdayIntegrationTest() {
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var createHelper: CreateHelper
+
+    @Autowired
+    private lateinit var userAccountService: UserAccountService
+
+    @Autowired
+    private lateinit var userAccountRepository: UserAccountRepository
+
+    private val baseUrl: String = "/api/user-accounts"
+
+    @Test
+    fun `should delete a user account when user has UserAuthority WRITE`() {
+        val admin = createHelper.createUser(setOf(UserAuthority.READ, UserAuthority.WRITE))
+        val target = createHelper.createUser(emptySet())
+        val account = userAccountService.generateKeyForUserCode(target.code, "test-key")!!
+
+        assertTrue(userAccountRepository.existsById(account.id))
+
+        mvc
+            .perform(
+                delete("$baseUrl/${account.id}")
+                    .with(user(CreateHelper.UserSecurity(admin)))
+                    .accept(APPLICATION_JSON),
+            ).asyncDispatch()
+            .andExpect(status().isOk)
+
+        assertFalse(userAccountRepository.existsById(account.id))
+    }
+
+    @Test
+    fun `should return 403 when user has no UserAuthority WRITE`() {
+        val reader = createHelper.createUser(setOf(UserAuthority.READ))
+        val target = createHelper.createUser(emptySet())
+        val account = userAccountService.generateKeyForUserCode(target.code, "test-key")!!
+
+        mvc
+            .perform(
+                delete("$baseUrl/${account.id}")
+                    .with(user(CreateHelper.UserSecurity(reader)))
+                    .accept(APPLICATION_JSON),
+            ).asyncDispatch()
+            .andExpect(status().isForbidden)
+
+        assertTrue(userAccountRepository.existsById(account.id))
+    }
+
+    private fun ResultActions.asyncDispatch() = mvc.perform(asyncDispatch(this.andReturn()))
+}

--- a/workday-user/src/main/react/user/UserAccountList.tsx
+++ b/workday-user/src/main/react/user/UserAccountList.tsx
@@ -1,0 +1,78 @@
+import DeleteIcon from '@mui/icons-material/Delete';
+import KeyIcon from '@mui/icons-material/Key';
+import PasswordIcon from '@mui/icons-material/Password';
+import PersonIcon from '@mui/icons-material/Person';
+import {
+  IconButton,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  ListSubheader,
+  Typography,
+} from '@mui/material';
+import type { UserAccount } from '@workday-user/user/response/user';
+
+type UserAccountListProps = {
+  accounts?: UserAccount[];
+  onDelete: (account: UserAccount) => void;
+};
+
+function describe(account: UserAccount): string {
+  switch (account.type) {
+    case 'OAUTH':
+      return account.provider ? `OAuth (${account.provider})` : 'OAuth';
+    case 'KEY':
+      return account.label ? `API key (${account.label})` : 'API key';
+    case 'PASSWORD':
+      return 'Password';
+    default:
+      return account.type ?? 'Account';
+  }
+}
+
+function icon(type?: string) {
+  switch (type) {
+    case 'OAUTH':
+      return <PersonIcon />;
+    case 'KEY':
+      return <KeyIcon />;
+    default:
+      return <PasswordIcon />;
+  }
+}
+
+export function UserAccountList({ accounts, onDelete }: UserAccountListProps) {
+  return (
+    <List subheader={<ListSubheader disableGutters>Accounts</ListSubheader>}>
+      {(!accounts || accounts.length === 0) && (
+        <Typography color="textSecondary">No accounts</Typography>
+      )}
+      {accounts?.map((account) => (
+        <ListItem
+          key={account.id}
+          disableGutters
+          secondaryAction={
+            <IconButton
+              edge="end"
+              aria-label="delete account"
+              onClick={() => onDelete(account)}
+            >
+              <DeleteIcon />
+            </IconButton>
+          }
+        >
+          <ListItemIcon>{icon(account.type)}</ListItemIcon>
+          <ListItemText
+            primary={describe(account)}
+            secondary={
+              account.created
+                ? new Date(account.created).toLocaleString()
+                : undefined
+            }
+          />
+        </ListItem>
+      ))}
+    </List>
+  );
+}

--- a/workday-user/src/main/react/user/UserClient.ts
+++ b/workday-user/src/main/react/user/UserClient.ts
@@ -89,6 +89,18 @@ export function deleteUser(id) {
   return fetch(`/api/users/${id}`, opts).then((res) => internalize<User>(res));
 }
 
+export function deleteUserAccount(id) {
+  const opts = {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+  };
+  return fetch(`/api/user-accounts/${id}`, opts).then((res) =>
+    internalize<void>(res),
+  );
+}
+
 export function resetUserPassword(id) {
   const opts = {
     method: 'PUT',
@@ -107,5 +119,6 @@ export default {
   createUser,
   updateUser,
   deleteUser,
+  deleteUserAccount,
   resetUserPassword,
 };

--- a/workday-user/src/main/react/user/UserDialog.tsx
+++ b/workday-user/src/main/react/user/UserDialog.tsx
@@ -6,8 +6,9 @@ import DialogActions from '@mui/material/DialogActions';
 import Typography from '@mui/material/Typography';
 import { ConfirmDialog } from '@workday-core/components/ConfirmDialog';
 import { DialogBody, DialogHeader } from '@workday-core/components/dialog';
-import type { User } from '@workday-user/user/response/user';
+import type { User, UserAccount } from '@workday-user/user/response/user';
 import { useEffect, useState } from 'react';
+import { UserAccountList } from './UserAccountList';
 import UserClient from './UserClient';
 import { USER_FORM_ID, UserForm } from './UserForm';
 
@@ -28,15 +29,21 @@ export function UserDialog({
 
   const [message, setMessage] = useState<string>(null);
   const [openDelete, setOpenDelete] = useState<boolean>(false);
+  const [deleteAccount, setDeleteAccount] = useState<UserAccount>(null);
   const [authorities, setAuthorities] = useState<string[]>(null);
 
+  const loadUser = (userId: string) => {
+    UserClient.findUserByid(userId)
+      .then((res) => setState(res))
+      .catch((err) => {
+        setMessage(err.message);
+      });
+  };
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: loadUser is stable; only id should retrigger the fetch
   useEffect(() => {
     if (id !== null) {
-      UserClient.findUserByid(id)
-        .then((res) => setState(res))
-        .catch((err) => {
-          setMessage(err.message);
-        });
+      loadUser(id);
     } else {
       setState(null);
     }
@@ -67,6 +74,17 @@ export function UserDialog({
 
   const handleCloseDelete = () => {
     setOpenDelete(false);
+  };
+
+  const handleDeleteAccount = () => {
+    UserClient.deleteUserAccount(deleteAccount.id)
+      .then(() => {
+        setDeleteAccount(null);
+        loadUser(state.id);
+      })
+      .catch((err) => {
+        setMessage(err.message);
+      });
   };
 
   const handleMessageClose = () => {
@@ -116,6 +134,12 @@ export function UserDialog({
             authorities={authorities}
             onSummit={handleSubmit}
           />
+          {state?.id && (
+            <UserAccountList
+              accounts={state.accounts}
+              onDelete={setDeleteAccount}
+            />
+          )}
         </DialogBody>
         <DialogActions>
           {enablePassword && state && state.id && (
@@ -139,6 +163,15 @@ export function UserDialog({
       >
         <Typography>
           Are you sure you want to delete user: {state?.name}?
+        </Typography>
+      </ConfirmDialog>
+      <ConfirmDialog
+        open={deleteAccount != null}
+        onClose={() => setDeleteAccount(null)}
+        onConfirm={handleDeleteAccount}
+      >
+        <Typography>
+          Are you sure you want to delete this account for {state?.name}?
         </Typography>
       </ConfirmDialog>
       <Snackbar

--- a/workday-user/src/main/react/user/index.ts
+++ b/workday-user/src/main/react/user/index.ts
@@ -1,3 +1,4 @@
+export * from './UserAccountList';
 export * from './UserClient';
 export * from './UserDialog';
 export * from './UserFeature';

--- a/workday-user/src/main/react/user/response/user.ts
+++ b/workday-user/src/main/react/user/response/user.ts
@@ -15,6 +15,10 @@ export interface UserGroup {
 
 export interface UserAccount {
   id: string;
+  type?: string;
+  created?: string;
+  label?: string;
+  provider?: string;
 }
 
 export interface UserAccountPassword extends UserAccount {


### PR DESCRIPTION
Add a DELETE /api/user-accounts/{id} endpoint gated by UserAuthority.WRITE
and surface each user's linked accounts (password, OAuth, API key) in the
user edit dialog with a delete action.

https://claude.ai/code/session_01Th1egE8tjYFSBnDJNgDNBj