### PR TITLE
chore: Upgrade wirespec to 0.18.13

### DIFF
--- a/.github/workflows/gcp.yml
+++ b/.github/workflows/gcp.yml
@@ -87,10 +87,7 @@ jobs:
       - name: Start backend server in background
         run: |
           echo "Starting backend server..."
-          # Use develop profile with ci addon (Google Drive integration disabled).
-          # Run wirespec deserialization in STRICT mode so request payloads carrying
-          # fields absent from their .ws Form contract fail here, instead of being
-          # silently tolerated by the prod-default lenient serializer.
+          # Use develop profile with ci addon (Google Drive integration disabled)
           ./mvnw -B compile spring-boot:run -DskipTests -Dspring-boot.run.profiles=develop,ci -Pdevelop -Dspring-boot.run.arguments=--workday.wirespec.lenient-deserialization=false > backend.log 2>&1 &
           echo $! > backend.pid
           echo "Backend server started with PID $(cat backend.pid)"

--- a/.github/workflows/gcp.yml
+++ b/.github/workflows/gcp.yml
@@ -87,8 +87,11 @@ jobs:
       - name: Start backend server in background
         run: |
           echo "Starting backend server..."
-          # Use develop profile with ci addon (Google Drive integration disabled)
-          ./mvnw -B compile spring-boot:run -DskipTests -Dspring-boot.run.profiles=develop,ci -Pdevelop > backend.log 2>&1 &
+          # Use develop profile with ci addon (Google Drive integration disabled).
+          # Run wirespec deserialization in STRICT mode so request payloads carrying
+          # fields absent from their .ws Form contract fail here, instead of being
+          # silently tolerated by the prod-default lenient serializer.
+          ./mvnw -B compile spring-boot:run -DskipTests -Dspring-boot.run.profiles=develop,ci -Pdevelop -Dspring-boot.run.arguments=--workday.wirespec.lenient-deserialization=false > backend.log 2>&1 &
           echo $! > backend.pid
           echo "Backend server started with PID $(cat backend.pid)"
 
@@ -104,6 +107,17 @@ jobs:
 
       - name: Run Playwright tests
         run: npm run test:e2e
+
+      - name: Assert no strict-deserialization regressions
+        if: always()
+        run: |
+          echo "Checking backend.log for wirespec strict-deserialization errors..."
+          if grep -q "UnrecognizedPropertyException" backend.log; then
+            echo "::error::A request payload sent fields absent from its .ws Form contract. Clean the payload (send only declared fields) or update the contract."
+            grep "Unrecognized field" backend.log | sort -u
+            exit 1
+          fi
+          echo "No strict-deserialization errors found."
 
       - name: Show backend logs on failure
         if: failure()

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.3.10",
-        "@flock/wirespec": "0.17.8",
+        "@flock/wirespec": "0.18.13",
         "@fontsource/material-icons": "^5.0.7",
         "@fontsource/roboto": "^5.0.8",
         "@playwright/test": "^1.53.1",
@@ -1339,16 +1339,14 @@
       }
     },
     "node_modules/@flock/wirespec": {
-      "version": "0.17.8",
-      "resolved": "https://registry.npmjs.org/@flock/wirespec/-/wirespec-0.17.8.tgz",
-      "integrity": "sha512-2H1/NNvT1ycUiE8BHndg7NuEltecEhOcK6QGH1HJ9kBkKpu3yr5udoy1XlTPxkrihJUfa843RXcnMRmGEbZf6w==",
+      "version": "0.18.13",
+      "resolved": "https://registry.npmjs.org/@flock/wirespec/-/wirespec-0.18.13.tgz",
+      "integrity": "sha512-NxXSqzTfovP58SS1m4lSjva0/6mjxlfKif7oM+lGHe6tlYwtPYsfDVykejXbxg4kweplVQkkG0Z3wWsn8d54eA==",
       "dev": true,
       "license": "Apache-2.0",
-      "dependencies": {
-        "format-util": "^1.0.5"
-      },
       "bin": {
-        "wirespec": "wirespec-bin.mjs"
+        "wirespec": "wirespec-bin.mjs",
+        "wirespec-lsp": "wirespec-lsp.mjs"
       }
     },
     "node_modules/@fontsource/material-icons": {
@@ -4975,13 +4973,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/format-util": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.5.tgz",
-      "integrity": "sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/formik": {
       "version": "2.4.9",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.10",
-    "@flock/wirespec": "0.17.8",
+    "@flock/wirespec": "0.18.13",
     "@fontsource/material-icons": "^5.0.7",
     "@fontsource/roboto": "^5.0.8",
     "@playwright/test": "^1.53.1",

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <spring.cloud.gcp.version>6.5.8</spring.cloud.gcp.version>
         <springdoc.version>2.8.6</springdoc.version>
         <springmockk.version>4.0.2</springmockk.version>
-        <wirespec.version>0.17.8</wirespec.version>
+        <wirespec.version>0.18.13</wirespec.version>
     </properties>
 
     <dependencyManagement>

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/config/WirespecSerializationConfig.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/config/WirespecSerializationConfig.kt
@@ -7,22 +7,6 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
 
-/**
- * Overrides wirespec's default request/response serialization.
- *
- * wirespec 0.18's WirespecSerializationConfiguration builds its serializer from a fresh
- * `jacksonObjectMapper()`, which keeps Jackson's default FAIL_ON_UNKNOWN_PROPERTIES=true.
- * That rejects existing frontend payloads carrying fields absent from the .ws Form contracts
- * (e.g. server-generated `id`/`code` round-tripped on edit) with HTTP 500. 0.17.8 instead
- * injected Spring's auto-configured ObjectMapper, which is lenient.
- *
- * This bean restores that behavior by feeding Spring's ObjectMapper (lenient by default)
- * into wirespec's serializer. @Primary makes it win over the auto-imported strict bean.
- *
- * Enabled by default; set `workday.wirespec.lenient-deserialization=false` to fall back
- * to wirespec's strict serializer (useful for surfacing payloads that send fields absent
- * from their .ws contract).
- */
 @Configuration
 @ConditionalOnProperty(
     prefix = "workday.wirespec",
@@ -31,8 +15,6 @@ import org.springframework.context.annotation.Primary
     matchIfMissing = true,
 )
 class WirespecSerializationConfig {
-    // Distinct bean name avoids colliding with wirespec's own `wirespecSerialization`
-    // bean; @Primary makes this the one that gets injected.
     @Bean
     @Primary
     fun lenientWirespecSerialization(objectMapper: ObjectMapper): WirespecSerialization =

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/config/WirespecSerializationConfig.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/config/WirespecSerializationConfig.kt
@@ -1,0 +1,40 @@
+package community.flock.eco.workday.application.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import community.flock.wirespec.integration.jackson.kotlin.WirespecSerialization
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+
+/**
+ * Overrides wirespec's default request/response serialization.
+ *
+ * wirespec 0.18's WirespecSerializationConfiguration builds its serializer from a fresh
+ * `jacksonObjectMapper()`, which keeps Jackson's default FAIL_ON_UNKNOWN_PROPERTIES=true.
+ * That rejects existing frontend payloads carrying fields absent from the .ws Form contracts
+ * (e.g. server-generated `id`/`code` round-tripped on edit) with HTTP 500. 0.17.8 instead
+ * injected Spring's auto-configured ObjectMapper, which is lenient.
+ *
+ * This bean restores that behavior by feeding Spring's ObjectMapper (lenient by default)
+ * into wirespec's serializer. @Primary makes it win over the auto-imported strict bean.
+ *
+ * Enabled by default; set `workday.wirespec.lenient-deserialization=false` to fall back
+ * to wirespec's strict serializer (useful for surfacing payloads that send fields absent
+ * from their .ws contract).
+ */
+@Configuration
+@ConditionalOnProperty(
+    prefix = "workday.wirespec",
+    name = ["lenient-deserialization"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
+class WirespecSerializationConfig {
+    // Distinct bean name avoids colliding with wirespec's own `wirespecSerialization`
+    // bean; @Primary makes this the one that gets injected.
+    @Bean
+    @Primary
+    fun lenientWirespecSerialization(objectMapper: ObjectMapper): WirespecSerialization =
+        WirespecSerialization(objectMapper)
+}

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/TodoController.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/TodoController.kt
@@ -4,7 +4,6 @@ import community.flock.eco.workday.api.endpoint.GetTodoAll
 import community.flock.eco.workday.api.model.Todo
 import community.flock.eco.workday.api.model.TodoType
 import community.flock.eco.workday.api.model.UUID
-import community.flock.eco.workday.api.model.validate
 import community.flock.eco.workday.application.authorities.LeaveDayAuthority
 import community.flock.eco.workday.application.authorities.SickdayAuthority
 import community.flock.eco.workday.application.authorities.WorkDayAuthority

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/Util.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/Util.kt
@@ -1,6 +1,5 @@
 package community.flock.eco.workday.application.controllers
 
-import community.flock.eco.workday.api.model.validate
 import community.flock.eco.workday.application.model.Person
 import org.springframework.security.core.Authentication
 import java.util.UUID

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/expense/ExpenseController.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/expense/ExpenseController.kt
@@ -12,7 +12,6 @@ import community.flock.eco.workday.api.model.CostExpenseFile
 import community.flock.eco.workday.api.model.Error
 import community.flock.eco.workday.api.model.ExpenseType
 import community.flock.eco.workday.api.model.TravelExpenseDetails
-import community.flock.eco.workday.api.model.validate
 import community.flock.eco.workday.application.controllers.isAssociatedWith
 import community.flock.eco.workday.application.interfaces.applyAllowedToUpdate
 import community.flock.eco.workday.application.services.DocumentStorage

--- a/workday-application/src/main/react/clients/PersonClient.ts
+++ b/workday-application/src/main/react/clients/PersonClient.ts
@@ -51,23 +51,23 @@ export type PersonRaw = {
   googleDriveId: string;
 };
 
+// Mirrors the wirespec PersonForm contract (workday-application/src/main/wirespec/persons.ws).
+// Keep in sync: fields absent here are rejected by the backend under strict deserialization.
 export type PersonRequest = {
-  id?: number;
-  uuid?: string;
-  lastName: string;
-  email: string;
-  position: string;
-  number?: number;
-  birthdate: string;
-  joinDate: string;
-  active: boolean;
-  lastActiveAt?: string; // FIXME
-  reminders: boolean;
-  receiveEmail: boolean;
-  user: any; // FIXME
+  firstname?: string;
+  lastname?: string;
+  email?: string;
+  position?: string;
+  number?: string;
+  birthdate?: string;
+  joinDate?: string;
+  active?: boolean;
+  userCode?: string;
+  reminders?: boolean;
+  receiveEmail?: boolean;
   shoeSize?: string;
   shirtSize?: string;
-  googleDriveId: string;
+  googleDriveId?: string;
 };
 
 const path = '/api/persons';

--- a/workday-application/src/main/react/clients/PersonClient.ts
+++ b/workday-application/src/main/react/clients/PersonClient.ts
@@ -51,8 +51,6 @@ export type PersonRaw = {
   googleDriveId: string;
 };
 
-// Mirrors the wirespec PersonForm contract (workday-application/src/main/wirespec/persons.ws).
-// Keep in sync: fields absent here are rejected by the backend under strict deserialization.
 export type PersonRequest = {
   firstname?: string;
   lastname?: string;

--- a/workday-application/src/main/react/features/client/ClientDialog.tsx
+++ b/workday-application/src/main/react/features/client/ClientDialog.tsx
@@ -25,10 +25,12 @@ export function ClientDialog({ open, code, onClose }: ClientDialogProps) {
   }, [code]);
 
   const handleSubmit = (value) => {
+    // ClientForm only declares `name`; wirespec 0.18 rejects id/code.
+    const body = { name: value.name };
     if (code) {
-      ClientClient.put(code, value).then(() => onClose?.());
+      ClientClient.put(code, body).then(() => onClose?.());
     } else {
-      ClientClient.post(value).then(() => onClose?.());
+      ClientClient.post(body).then(() => onClose?.());
     }
   };
 

--- a/workday-application/src/main/react/features/client/ClientDialog.tsx
+++ b/workday-application/src/main/react/features/client/ClientDialog.tsx
@@ -25,7 +25,6 @@ export function ClientDialog({ open, code, onClose }: ClientDialogProps) {
   }, [code]);
 
   const handleSubmit = (value) => {
-    // ClientForm only declares `name`; wirespec 0.18 rejects id/code.
     const body = { name: value.name };
     if (code) {
       ClientClient.put(code, body).then(() => onClose?.());

--- a/workday-application/src/main/react/features/holiday/LeaveDayFeature.tsx
+++ b/workday-application/src/main/react/features/holiday/LeaveDayFeature.tsx
@@ -33,12 +33,16 @@ export function LeaveDayFeature({ person }: LeaveDayFeatureProps) {
   }
 
   function handleStatusChange(status, it) {
+    // Send only LeaveDayForm fields; wirespec 0.18 rejects unknown fields (id, code).
     LeaveDayClient.put(it.code, {
-      ...it,
-      status,
+      description: it.description,
       from: it.from.format(ISO_8601_DATE),
       to: it.to.format(ISO_8601_DATE),
+      hours: it.hours,
       days: it.days.length > 0 ? it.days : null,
+      status,
+      type: it.type,
+      personId: it.personId,
     }).then(() => setRefresh(!refresh));
   }
 

--- a/workday-application/src/main/react/features/holiday/LeaveDayFeature.tsx
+++ b/workday-application/src/main/react/features/holiday/LeaveDayFeature.tsx
@@ -33,7 +33,6 @@ export function LeaveDayFeature({ person }: LeaveDayFeatureProps) {
   }
 
   function handleStatusChange(status, it) {
-    // Send only LeaveDayForm fields; wirespec 0.18 rejects unknown fields (id, code).
     LeaveDayClient.put(it.code, {
       description: it.description,
       from: it.from.format(ISO_8601_DATE),

--- a/workday-application/src/main/react/features/person/PersonDialog.tsx
+++ b/workday-application/src/main/react/features/person/PersonDialog.tsx
@@ -19,15 +19,28 @@ export const PersonDialog = ({ open, onClose, item }: PersonDialogProps) => {
   };
 
   type PersonRequestRaw = PersonRequest & {
-    birthdate: Dayjs;
-    joinDate: Dayjs;
+    birthdate?: Dayjs;
+    joinDate?: Dayjs;
   };
 
   const handleSubmit = (values: PersonRequestRaw) => {
-    const body = {
-      ...values,
+    // Send only PersonForm contract fields; the form's `values` also carry entity-only
+    // fields (id, uuid, fullName, user, lastActiveAt, code) that wirespec 0.18 rejects.
+    const body: PersonRequest = {
+      firstname: values.firstname,
+      lastname: values.lastname,
+      email: values.email,
+      position: values.position,
+      number: values.number,
       birthdate: values.birthdate?.format(ISO_8601_DATE),
       joinDate: values.joinDate?.format(ISO_8601_DATE),
+      active: values.active,
+      userCode: values.userCode,
+      reminders: values.reminders,
+      receiveEmail: values.receiveEmail,
+      shoeSize: values.shoeSize,
+      shirtSize: values.shirtSize,
+      googleDriveId: values.googleDriveId,
     };
 
     if (item) {

--- a/workday-application/src/main/react/features/person/PersonDialog.tsx
+++ b/workday-application/src/main/react/features/person/PersonDialog.tsx
@@ -24,8 +24,6 @@ export const PersonDialog = ({ open, onClose, item }: PersonDialogProps) => {
   };
 
   const handleSubmit = (values: PersonRequestRaw) => {
-    // Send only PersonForm contract fields; the form's `values` also carry entity-only
-    // fields (id, uuid, fullName, user, lastActiveAt, code) that wirespec 0.18 rejects.
     const body: PersonRequest = {
       firstname: values.firstname,
       lastname: values.lastname,

--- a/workday-application/src/main/react/features/project/ProjectDialog.tsx
+++ b/workday-application/src/main/react/features/project/ProjectDialog.tsx
@@ -25,7 +25,6 @@ export default function ProjectDialog({
   const [disableDeleteReason, setDisableDeleteReason] = useState('');
 
   const handleSubmit = (project: Project) => {
-    // ProjectForm only declares `name`; wirespec 0.18 rejects id/code.
     const body = { name: project.name };
     const persistPromise = project.code
       ? ProjectClient.put(project.code, body)

--- a/workday-application/src/main/react/features/project/ProjectDialog.tsx
+++ b/workday-application/src/main/react/features/project/ProjectDialog.tsx
@@ -25,9 +25,11 @@ export default function ProjectDialog({
   const [disableDeleteReason, setDisableDeleteReason] = useState('');
 
   const handleSubmit = (project: Project) => {
+    // ProjectForm only declares `name`; wirespec 0.18 rejects id/code.
+    const body = { name: project.name };
     const persistPromise = project.code
-      ? ProjectClient.put(project.code, project)
-      : ProjectClient.post(project);
+      ? ProjectClient.put(project.code, body)
+      : ProjectClient.post(body);
 
     persistPromise.then(closeDialog);
   };

--- a/workday-application/src/main/react/features/sickday/SickDayFeature.tsx
+++ b/workday-application/src/main/react/features/sickday/SickDayFeature.tsx
@@ -34,11 +34,15 @@ export function SickDayFeature({ person }: SickDayFeatureProps) {
   }
 
   function handleStatusChange(status: string, it: DayProps) {
+    // Send only SickDayForm fields; wirespec 0.18 rejects unknown fields (id, code, type).
     SickDayClient.put(it.code, {
-      ...it,
-      status,
       from: it.from.format(ISO_8601_DATE),
       to: it.to.format(ISO_8601_DATE),
+      hours: it.hours,
+      days: it.days,
+      status,
+      description: it.description,
+      personId: it.personId,
     }).then(() => setRefresh(!refresh));
   }
 

--- a/workday-application/src/main/react/features/sickday/SickDayFeature.tsx
+++ b/workday-application/src/main/react/features/sickday/SickDayFeature.tsx
@@ -34,7 +34,6 @@ export function SickDayFeature({ person }: SickDayFeatureProps) {
   }
 
   function handleStatusChange(status: string, it: DayProps) {
-    // Send only SickDayForm fields; wirespec 0.18 rejects unknown fields (id, code, type).
     SickDayClient.put(it.code, {
       from: it.from.format(ISO_8601_DATE),
       to: it.to.format(ISO_8601_DATE),

--- a/workday-application/src/main/react/features/todo/TodoService.tsx
+++ b/workday-application/src/main/react/features/todo/TodoService.tsx
@@ -5,8 +5,6 @@ import { ISO_8601_DATE } from '../../clients/util/DateFormats';
 import { WorkDayClient } from '../../clients/WorkDayClient';
 import type { Todo, WorkDayStatus } from '../../wirespec/model';
 
-// These flows previously PUT the whole fetched entity; wirespec 0.18 rejects fields
-// absent from the *Form contracts, so send only the declared fields.
 const updateStatusWorkDay = async (id: string, status: WorkDayStatus) => {
   const res = await WorkDayClient.get(id);
   await WorkDayClient.put(id, {

--- a/workday-application/src/main/react/features/todo/TodoService.tsx
+++ b/workday-application/src/main/react/features/todo/TodoService.tsx
@@ -5,35 +5,45 @@ import { ISO_8601_DATE } from '../../clients/util/DateFormats';
 import { WorkDayClient } from '../../clients/WorkDayClient';
 import type { Todo, WorkDayStatus } from '../../wirespec/model';
 
+// These flows previously PUT the whole fetched entity; wirespec 0.18 rejects fields
+// absent from the *Form contracts, so send only the declared fields.
 const updateStatusWorkDay = async (id: string, status: WorkDayStatus) => {
   const res = await WorkDayClient.get(id);
   await WorkDayClient.put(id, {
-    ...res,
-    assignmentCode: res.assignment.code,
-    status,
     from: res.from.format(ISO_8601_DATE),
     to: res.to.format(ISO_8601_DATE),
+    hours: res.hours,
+    days: res.days,
+    status,
+    assignmentCode: res.assignment.code,
+    sheets: res.sheets,
   });
 };
 
 const updateStatusSickDay = async (id: string, status: WorkDayStatus) => {
   const res = await SickDayClient.get(id);
   await SickDayClient.put(id, {
-    ...res,
-    status,
     from: res.from.format(ISO_8601_DATE),
     to: res.to.format(ISO_8601_DATE),
+    hours: res.hours,
+    days: res.days,
+    status,
+    description: res.description,
+    personId: res.personId,
   });
 };
 
 const updateStatusLeaveDay = async (id: string, status: WorkDayStatus) => {
   const res = await LeaveDayClient.get(id);
   await LeaveDayClient.put(id, {
-    ...res,
-    status,
+    description: res.description,
     from: res.from.format(ISO_8601_DATE),
     to: res.to.format(ISO_8601_DATE),
+    hours: res.hours,
     days: res.type === 'HOLIDAY' ? res.days : undefined,
+    status,
+    type: res.type,
+    personId: res.personId,
   });
 };
 

--- a/workday-application/src/main/react/features/workday/WorkDayFeature.tsx
+++ b/workday-application/src/main/react/features/workday/WorkDayFeature.tsx
@@ -41,7 +41,6 @@ export function WorkDayFeature({ person }: WorkDayFeatureProps) {
   }
 
   function handleStatusChange(status, it) {
-    // Send only WorkDayForm fields; wirespec 0.18 rejects unknown fields (id, code, assignment, type).
     WorkDayClient.put(it.code, {
       from: it.from.format(ISO_8601_DATE),
       to: it.to.format(ISO_8601_DATE),

--- a/workday-application/src/main/react/features/workday/WorkDayFeature.tsx
+++ b/workday-application/src/main/react/features/workday/WorkDayFeature.tsx
@@ -41,13 +41,15 @@ export function WorkDayFeature({ person }: WorkDayFeatureProps) {
   }
 
   function handleStatusChange(status, it) {
+    // Send only WorkDayForm fields; wirespec 0.18 rejects unknown fields (id, code, assignment, type).
     WorkDayClient.put(it.code, {
-      ...it,
       from: it.from.format(ISO_8601_DATE),
       to: it.to.format(ISO_8601_DATE),
+      hours: it.hours,
+      days: it.days.length > 0 ? it.days : null,
       status,
       assignmentCode: it.assignment.code,
-      days: it.days.length > 0 ? it.days : null,
+      sheets: it.sheets,
     }).then(() => setRefresh(!refresh));
   }
 


### PR DESCRIPTION
Re-applies the wirespec 0.18.13 bump that was reverted from PR #491 (commit 7d7295b4), now with the frontend fix that was missing.

**Why it 500'd before:** 0.18's Spring integration builds its (de)serializer from a fresh `jacksonObjectMapper()` (strict `FAIL_ON_UNKNOWN_PROPERTIES=true`) instead of the Spring-managed lenient mapper 0.17.8 reused. Frontend edit/approve flows PUT the whole fetched entity, so server-generated `id` (and `code`, etc.) tripped strict deserialization.

**Fix (defense-in-depth):**
- `@Primary Wirespec.Serialization` bean fed Spring's lenient `ObjectMapper` (toggle `workday.wirespec.lenient-deserialization`, default on) — restores 0.17.8 behavior systemically and protects prod.
- Confirmed offender payloads now send only contract fields: Project/Client dialogs, Sick/Work/Leave approve flows (`*Feature.tsx` + `TodoService`), and PersonDialog. `PersonRequest` type realigned to the `PersonForm` contract so future drift is a compile error.
- **CI runs e2e in strict mode** (`lenient-deserialization=false`) and fails on any `UnrecognizedPropertyException`, so the lenient bean is never load-bearing — payload drift breaks CI loudly instead of being silently swallowed.

**Verification:** full strict e2e run logs **zero** `UnrecognizedPropertyException`. Remaining spec failures are pre-existing flakiness (untouched flows fail identically; pass on `--retries=2`, which CI uses).

> Note: stacked on `worktree-java21-kotlin-upgrade` (PR #491) — merge that first, then rebase to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)