### PR TITLE
fix: eliminate Hibernate 6 test-isolation flakiness (transient Person)

### DIFF
--- a/workday-application/src/test/kotlin/community/flock/eco/workday/utils/CleanupDbService.kt
+++ b/workday-application/src/test/kotlin/community/flock/eco/workday/utils/CleanupDbService.kt
@@ -22,7 +22,8 @@ open class CleanupDbService(
                         try {
                             disableConstraints(statement)
                             truncateTables(statement, H2_SCHEMA_NAME)
-                            resetSequences(statement, H2_SCHEMA_NAME)
+                            // No sequence reset: it desyncs Hibernate 6's pooled id optimizer from
+                            // the DB (shared SessionFactory, reuseForks=true) -> transient flakes.
                         } finally {
                             enableConstraints(statement)
                         }
@@ -36,19 +37,6 @@ open class CleanupDbService(
                 throw e
             }
         }
-    }
-
-    private fun resetSequences(
-        statement: Statement,
-        schemaName: String,
-    ) {
-        getSchemaSequences(statement, schemaName)
-            .forEach({ sequenceName ->
-                executeStatement(
-                    statement,
-                    "ALTER SEQUENCE \"$sequenceName\" RESTART WITH 1",
-                )
-            })
     }
 
     private fun truncateTables(
@@ -81,14 +69,6 @@ open class CleanupDbService(
         schemaName: String,
     ): Set<String?> {
         val sql = "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES  where TABLE_SCHEMA='$schemaName'"
-        return queryForList(statement, sql)
-    }
-
-    private fun getSchemaSequences(
-        statement: Statement,
-        schemaName: String,
-    ): Set<String?> {
-        val sql = "SELECT SEQUENCE_NAME FROM INFORMATION_SCHEMA.SEQUENCES WHERE SEQUENCE_SCHEMA='$schemaName'"
         return queryForList(statement, sql)
     }
 


### PR DESCRIPTION
## Problem

Since the Java 21 / Kotlin 2.3 / Spring Boot 3.5 / **Hibernate 6** upgrade in #491, the `workday-application` test suite (`mvn package`) intermittently fails with:

```
org.hibernate.TransientObjectException: persistent instance references an
unsaved transient instance of 'community.flock.eco.workday.application.model.Person'
(save the transient instance before flushing)
```

The failing test **varies between runs** (`SickDayControllerTest`, `HoliDayRepositoryTest`, …) and each passes in isolation — the hallmark of cross-test state bleed, not a bug in any one test.

## Root cause

`CleanupDbService` (run in `@AfterEach`) truncates every table **and** resets every sequence (`ALTER SEQUENCE … RESTART WITH 1`).

Under Hibernate 6, the default `AUTO` id generator (`@GeneratedValue(strategy = AUTO)` in `AbstractIdEntity`) uses a **pooled sequence optimizer** that caches a block of ids in memory on the `SessionFactory`. Surefire runs the suite with `reuseForks=true` (the default — no surefire config overrides it), so that one `SessionFactory` is shared across all 212 tests.

Resetting the DB sequence after each test **desyncs it from the in-memory optimizer**. Depending on test execution order, a later insert gets an id the optimizer/session no longer considers persisted, and the next flush of a child entity (`SickDay`/`LeaveDay`) referencing that `Person` throws `TransientObjectException`. Hibernate 5 did not cache ids this way, which is why this only began with #491.

## Fix

Stop resetting sequences in the test cleanup. Truncation alone gives each test an empty schema; letting ids grow monotonically keeps the optimizer and the DB sequence coherent. No test asserts on specific id values (verified across the suite).

One file, test-only — no production code touched.

## Verification

Full `workday-application` suite, random run order (`-Dsurefire.runOrder=random`):

| | result |
|---|---|
| before (main) | failed ~**1 in 11** runs (transient `Person`) |
| after (this PR) | **15/15** clean |

## Out of scope (noted, not fixed here)
- `WorkdayEmailServiceTest` asserts the English month name (`"January"`) but `WorkdayEmailService` formats months with `LocaleContextHolder.getLocale()` (= JVM default locale). It passes on CI (`en_US`) but fails on a non-English machine. Deterministic and locale-dependent — separate from this flakiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)