### PR TITLE
chore: Upgrade GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/gcp.yml
+++ b/.github/workflows/gcp.yml
@@ -19,6 +19,11 @@ jobs:
       id-token: "write"
       pull-requests: "write"
 
+    # peaceiris/actions-gh-pages has no Node 24 release yet; force it (and any
+    # other Node 20 actions) onto Node 24 to clear the deprecation warning.
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/gcp.yml
+++ b/.github/workflows/gcp.yml
@@ -21,19 +21,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - id: "auth"
         name: "Authenticate to Google Cloud"
         if: github.actor != 'dependabot[bot]'
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@v3"
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDED }}
           service_account: ${{ secrets.GCP_SA_EMAIL }}
 
       - name: Setup gcloud environment
         if: github.actor != 'dependabot[bot]'
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Google cloud info
         if: github.actor != 'dependabot[bot]'
@@ -43,20 +43,20 @@ jobs:
         if: github.actor != 'dependabot[bot]'
         run: gcloud auth configure-docker
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "21"
 
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: "npm"
@@ -73,7 +73,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
@@ -127,7 +127,7 @@ jobs:
           fi
 
       - name: Upload Playwright test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report
@@ -164,7 +164,7 @@ jobs:
 
       - name: Comment Playwright report link on PR
         if: always() && github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && hashFiles('playwright-report/index.html') != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const dir = `pr-${context.issue.number}`;

--- a/.github/workflows/gcp.yml
+++ b/.github/workflows/gcp.yml
@@ -19,8 +19,6 @@ jobs:
       id-token: "write"
       pull-requests: "write"
 
-    # peaceiris/actions-gh-pages has no Node 24 release yet; force it (and any
-    # other Node 20 actions) onto Node 24 to clear the deprecation warning.
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 


### PR DESCRIPTION
Bumps all first-party actions to their latest Node 24-based majors (checkout v6, auth v3, setup-gcloud v3, setup-java v5, cache v5, setup-node v6, upload-artifact v7, github-script v9), clearing the Node 20 deprecation warning in CI.

`peaceiris/actions-gh-pages` has no Node 24 release yet, so the job sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to run it (and any stragglers) on Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)