### PR TITLE
Fix contract & assignment sort ordering broken by wirespec migration

### DIFF
--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/AssignmentController.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/AssignmentController.kt
@@ -10,11 +10,11 @@ import community.flock.eco.workday.application.forms.AssignmentForm
 import community.flock.eco.workday.application.model.Assignment
 import community.flock.eco.workday.application.services.AssignmentService
 import community.flock.eco.workday.application.services.WorkDayService
+import community.flock.eco.workday.application.utils.parseSort
 import community.flock.eco.workday.user.model.User
 import community.flock.eco.workday.user.services.UserService
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Sort
 import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.context.SecurityContextHolder
@@ -185,8 +185,6 @@ class AssignmentController(
             to = to?.let(LocalDate::parse),
         )
 
-    private fun GetAssignmentAll.Queries.toPageable(): Pageable {
-        val sort = sort?.takeIf { it.isNotBlank() }?.let { Sort.by(it) } ?: Sort.unsorted()
-        return PageRequest.of(page ?: 0, size ?: 20, sort)
-    }
+    private fun GetAssignmentAll.Queries.toPageable(): Pageable =
+        PageRequest.of(page ?: 0, size ?: 20, parseSort(sort))
 }

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/ContractController.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/ContractController.kt
@@ -21,11 +21,11 @@ import community.flock.eco.workday.application.model.ContractExternal
 import community.flock.eco.workday.application.model.ContractInternal
 import community.flock.eco.workday.application.model.ContractManagement
 import community.flock.eco.workday.application.model.ContractService
+import community.flock.eco.workday.application.utils.parseSort
 import community.flock.eco.workday.user.model.User
 import community.flock.eco.workday.user.services.UserService
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Sort
 import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.context.SecurityContextHolder
@@ -360,25 +360,6 @@ class ContractController(
             to = to?.let(LocalDate::parse),
         )
 
-    private fun GetContractAll.Queries.toPageable(): Pageable {
-        val sortOrder = sort?.takeIf { it.isNotBlank() }?.let(::parseSort) ?: Sort.unsorted()
-        return PageRequest.of(page ?: 0, size ?: 20, sortOrder)
-    }
-
-    private fun parseSort(spec: String): Sort =
-        spec
-            .split(",")
-            .map { it.trim() }
-            .filter { it.isNotEmpty() }
-            .let { parts ->
-                when {
-                    parts.isEmpty() -> Sort.unsorted()
-                    parts.size == 1 -> Sort.by(parts[0])
-                    parts.last().equals("asc", ignoreCase = true) ->
-                        Sort.by(Sort.Direction.ASC, *parts.dropLast(1).toTypedArray())
-                    parts.last().equals("desc", ignoreCase = true) ->
-                        Sort.by(Sort.Direction.DESC, *parts.dropLast(1).toTypedArray())
-                    else -> Sort.by(*parts.toTypedArray())
-                }
-            }
+    private fun GetContractAll.Queries.toPageable(): Pageable =
+        PageRequest.of(page ?: 0, size ?: 20, parseSort(sort))
 }

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/utils/WirespecUtils.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/utils/WirespecUtils.kt
@@ -3,6 +3,7 @@ package community.flock.eco.workday.application.utils
 import community.flock.eco.workday.domain.common.Direction
 import community.flock.eco.workday.domain.common.Pageable
 import community.flock.eco.workday.domain.common.Sort
+import org.springframework.data.domain.Sort as SpringSort
 
 fun toDomain(
     page: Int,
@@ -15,6 +16,40 @@ fun toDomain(
         size = size,
         sort = sort.consumeSorting(defaultSort),
     )
+
+/**
+ * Parses a wirespec-delivered sort list into a Spring [SpringSort].
+ *
+ * Wirespec splits comma-separated query values, so `?sort=from,desc` arrives as
+ * `["from", "desc"]`. Pairs are interpreted as (property, direction); a trailing
+ * unpaired token is treated as an ascending property.
+ */
+fun parseSort(sort: List<String>?): SpringSort {
+    val tokens = sort?.map(String::trim)?.filter(String::isNotEmpty).orEmpty()
+    if (tokens.isEmpty()) return SpringSort.unsorted()
+
+    val orders = mutableListOf<SpringSort.Order>()
+    var i = 0
+    while (i < tokens.size) {
+        val property = tokens[i]
+        val direction = tokens.getOrNull(i + 1)?.let(::asDirection)
+        if (direction != null) {
+            orders += SpringSort.Order(direction, property)
+            i += 2
+        } else {
+            orders += SpringSort.Order.asc(property)
+            i += 1
+        }
+    }
+    return SpringSort.by(orders)
+}
+
+private fun asDirection(token: String): SpringSort.Direction? =
+    when {
+        token.equals("asc", ignoreCase = true) -> SpringSort.Direction.ASC
+        token.equals("desc", ignoreCase = true) -> SpringSort.Direction.DESC
+        else -> null
+    }
 
 /**
  * Sorting parameters can be send in various formats.

--- a/workday-application/src/main/wirespec/assignments.ws
+++ b/workday-application/src/main/wirespec/assignments.ws
@@ -1,4 +1,4 @@
-endpoint GetAssignmentAll GET /api/assignments ? {personId: String?, projectCode: String?, to: String?, page: Integer32?, size: Integer32?, sort: String?} -> {
+endpoint GetAssignmentAll GET /api/assignments ? {personId: String?, projectCode: String?, to: String?, page: Integer32?, size: Integer32?, sort: String[]?} -> {
   200 -> Assignment[] # { `x-total`: Integer32 }
 }
 endpoint GetAssignmentByCode GET /api/assignments/{code: String} -> {

--- a/workday-application/src/main/wirespec/contracts.ws
+++ b/workday-application/src/main/wirespec/contracts.ws
@@ -1,4 +1,4 @@
-endpoint GetContractAll GET /api/contracts ? {personId: String?, to: String?, start: String?, end: String?, page: Integer32?, size: Integer32?, sort: String?} -> {
+endpoint GetContractAll GET /api/contracts ? {personId: String?, to: String?, start: String?, end: String?, page: Integer32?, size: Integer32?, sort: String[]?} -> {
   200 -> Contract[] # { `x-total`: Integer32 }
 }
 endpoint GetContractByCode GET /api/contracts/{code: String} -> {

--- a/workday-application/src/test/kotlin/community/flock/eco/workday/controllers/AssignmentControllerTest.kt
+++ b/workday-application/src/test/kotlin/community/flock/eco/workday/controllers/AssignmentControllerTest.kt
@@ -208,6 +208,38 @@ class AssignmentControllerTest(
     }
 
     @Test
+    fun `paged list returns assignments sorted by from descending when requested`() {
+        val adminUser = createHelper.createUserEntity(adminAuthorities)
+        val client = createHelper.createClient()
+        val person = createHelper.createPersonEntity()
+        listOf(
+            LocalDate.of(2024, 1, 1),
+            LocalDate.of(2024, 3, 1),
+            LocalDate.of(2024, 2, 1),
+        ).forEach { from ->
+            createHelper.createAssignment(
+                client = client,
+                person = person,
+                from = from,
+                to = from.plusMonths(1),
+            )
+        }
+
+        mvc
+            .perform(
+                get("$baseUrl?personId=${person.uuid}&page=0&size=10&sort=from,desc")
+                    .with(user(CreateHelper.UserSecurity(adminUser.toDomain())))
+                    .accept(APPLICATION_JSON),
+            ).asyncDispatch()
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(APPLICATION_JSON))
+            .andExpect(jsonPath("$.length()").value(3))
+            .andExpect(jsonPath("$[0].from").value("2024-03-01"))
+            .andExpect(jsonPath("$[1].from").value("2024-02-01"))
+            .andExpect(jsonPath("$[2].from").value("2024-01-01"))
+    }
+
+    @Test
     fun `non-write user should see hourlyRate set to 0 when fetching by code`() {
         val readOnlyUser = createHelper.createUserEntity(setOf(AssignmentAuthority.READ))
         val client = createHelper.createClient()

--- a/workday-application/src/test/kotlin/community/flock/eco/workday/controllers/ContractControllerTest.kt
+++ b/workday-application/src/test/kotlin/community/flock/eco/workday/controllers/ContractControllerTest.kt
@@ -369,6 +369,8 @@ class ContractControllerTest(
             .andExpect(status().isOk)
             .andExpect(content().contentType(APPLICATION_JSON))
             .andExpect(jsonPath("$.length()").value(2))
+            .andExpect(jsonPath("$[0].from").value("2024-03-01"))
+            .andExpect(jsonPath("$[1].from").value("2024-02-01"))
             .andExpect(header().string("x-total", "3"))
     }
 


### PR DESCRIPTION
The Wirespec query-string parser splits values on commas, then for a
`String?` query param keeps only the first element. As a result
`?sort=from,desc` arrived at the controllers as just `"from"`, so all
listings came back ascending regardless of the requested direction.
PR #486's parseSort in ContractController never saw the `desc` token
and PR #475 left AssignmentController without any parsing at all.

Declare `sort` as `String[]?` in the wirespec contracts (matching the
existing pattern in expenses.ws and misc.ws) and parse the resulting
list of [property, direction, ...] tokens in a shared helper.