### PR TITLE
Add work, sick, and leave hours tools to the Workday MCP server

### DIFF
--- a/workday-mcp/CLAUDE.md
+++ b/workday-mcp/CLAUDE.md
@@ -2,8 +2,8 @@
 
 A **local** [MCP](https://modelcontextprotocol.io) server (stdio) that exposes
 flock-eco-workday functionality to an MCP client such as Claude. It is a thin wrapper over the
-existing Workday REST API — it adds no business logic of its own. Tooling starts with expenses
-and grows from there (see Tools below).
+existing Workday REST API — it adds no business logic of its own. Tooling covers expenses and the
+work / sick / leave hours flows, and grows from there (see Tools below).
 
 **Topology:** the MCP client (Claude Desktop/Code) launches this server as a local
 subprocess and talks to it over stdio; the server then makes HTTPS calls to the **remote**
@@ -31,6 +31,39 @@ output (`src/wirespec/`) is gitignored and bundled into `dist/` by tsup.
   `POST /api/expenses/files` (→ a document UUID), then `POST /api/expenses-cost` references them as
   `files: [{ name, file }]`. All files are uploaded before the expense is created, so a failed
   upload never leaves a half-created expense.
+
+### Hours (work / sick / leave)
+
+Six tools, each a thin pass-through to the generated Wirespec client (`WorkdayClient.listWorkDays` /
+`createWorkDay`, and the `…SickDay` / `…LeaveDay` equivalents), plus `list_assignments`
+(`GetAssignmentAll`) so the model can discover an `assignmentCode`. All default `personId` to the key
+owner (via `getMyPersonId()`) with an optional admin override, and list tools use the `x-total` header
+for the count (same pattern as `listExpenses`). List calls pass `sort: undefined` — the controllers
+sort server-side (`from DESC, id ASC`).
+
+- `list_work_hours` / `register_work_hours` — `GET`/`POST /api/workdays`. Work hours attach to an
+  **assignment**, so `register_work_hours` requires an `assignmentCode` (not a `personId`); `sheets`
+  is left unset. Needs `WorkDayAuthority.READ` / `.WRITE`.
+- `list_assignments` — `GET /api/assignments`. Helper for finding the `assignmentCode`. Needs
+  `AssignmentAuthority.READ`.
+- `list_sick_hours` / `register_sick_hours` — `GET`/`POST /api/sickdays`. Attaches to the person
+  (optional `description`). Needs `SickdayAuthority.READ` / `.WRITE`.
+- `list_leave_hours` / `register_leave_hours` — `GET`/`POST /api/leave-days`. Attaches to the person
+  (`description`, optional `type` — defaults `HOLIDAY`). Needs `LeaveDayAuthority.READ` / `.WRITE`.
+
+All registrations submit with status `REQUESTED`. Forms share `from`/`to` (`YYYY-MM-DD`), a total
+`hours`, and an optional per-day `days` override. The shared input-schema fragments
+(`limitSchema`, `personIdSchema`, `dateSchema`, `hoursSchema`, `daysSchema`) and the
+`toolResult` / `summaryWithJson` helpers in `index.ts` keep the handlers uniform.
+
+### Server `instructions` (UX guidance)
+
+`index.ts` passes an `instructions` string to the `McpServer` constructor (2nd arg). The SDK returns
+it in the MCP `initialize` response and clients surface it to the model as standing guidance for the
+whole server — it is **not** a tool. It is the home for cross-tool workflow rules, notably: before
+`register_work_hours`, call `list_work_hours` to reuse the most recent `assignmentCode` (falling back
+to `list_assignments`) and confirm with the user. Per-tool `description`s carry the same hints so they
+also apply when a client ignores `instructions`. Keep prescriptive guidance here, not in code.
 
 The multipart upload (`WorkdayClient.uploadExpenseFile`) **bypasses the generated Wirespec client**
 and calls `fetch` directly: `Wirespec.RawRequest.body` is `string`-only and the shared `handle()`

--- a/workday-mcp/README.md
+++ b/workday-mcp/README.md
@@ -14,9 +14,18 @@ available.
 | --- | --- |
 | `list_expenses` | Lists your submitted expenses. Optional `limit` (default 25). Admins can pass a `personId` to view someone else's. |
 | `submit_cost_expense` | Creates a cost expense with one or more receipt attachments. You provide the amount, date, a short description, and the receipt(s) — as file path(s) on this machine, or as inline base64. Submitted with status `REQUESTED`; needs write permission. Admins can pass a `personId`. |
+| `list_work_hours` | Lists your registered work hours (most recent first), including the assignment each was logged against. Optional `limit`; admins can pass a `personId`. |
+| `register_work_hours` | Registers work hours against an assignment (`assignmentCode` required). Provide a date range and hours. Claude will normally reuse the assignment from your most recent entry — see `list_work_hours` / `list_assignments`. Submitted as `REQUESTED`; needs write permission. |
+| `list_assignments` | Lists your assignments, so you (and Claude) can find the `assignmentCode` to log work hours against. Optional `limit`; admins can pass a `personId`. |
+| `list_sick_hours` | Lists your registered sick hours (most recent first). Optional `limit`; admins can pass a `personId`. |
+| `register_sick_hours` | Registers sick hours for a person (no assignment needed). Provide a date range, hours, and an optional description. Submitted as `REQUESTED`; needs write permission. |
+| `list_leave_hours` | Lists your registered leave hours — holiday and other leave (most recent first). Optional `limit`; admins can pass a `personId`. |
+| `register_leave_hours` | Registers leave hours for a person (no assignment needed). Provide a description, date range, and hours; `type` defaults to `HOLIDAY`. Submitted as `REQUESTED`; needs write permission. |
 
 Once it's connected, just ask Claude in plain language — for example, _"list my last 5 Workday
-expenses"_, or _"submit this receipt as an expense"_.
+expenses"_, _"submit this receipt as an expense"_, _"log 8 hours of work for yesterday"_, or
+_"register a sick day for today"_. When you log work hours, Claude will check your latest entry and
+suggest reusing the same assignment.
 
 > **Note on attachments:** `submit_cost_expense` needs the receipt bytes, supplied one of two ways:
 > **(1)** `filePaths` — path(s) to file(s) on the machine running this server (works when the file

--- a/workday-mcp/src/client.ts
+++ b/workday-mcp/src/client.ts
@@ -1,6 +1,16 @@
 import { client } from "./wirespec/client.js";
 import type { Wirespec } from "./wirespec/Wirespec.js";
-import type { CostExpenseInput, Expense } from "./wirespec/model/index.js";
+import type {
+  Assignment,
+  CostExpenseInput,
+  Expense,
+  LeaveDay,
+  LeaveDayForm,
+  SickDay,
+  SickDayForm,
+  WorkDay,
+  WorkDayForm,
+} from "./wirespec/model/index.js";
 import { serialization } from "./wirespec-serialization.js";
 
 // Public Ory Oathkeeper gateway that transparently proxies to the Spring backend and
@@ -171,6 +181,89 @@ export class WorkdayClient {
     }
     return res.body;
   }
+
+  // ── Work hours ───────────────────────────────────────────────────────────
+  // The list endpoints sort server-side, so `sort` is left undefined (every key
+  // must still be present — the generated params type them as `T | undefined`).
+
+  /** List a person's work-hour entries. `total` comes from the `x-total` header. */
+  async listWorkDays(personId: string, size: number): Promise<{ items: WorkDay[]; total: number }> {
+    const { body: items, headers } = await this.wire.GetWorkDayAll({
+      personId,
+      page: 0,
+      size,
+      sort: undefined,
+    });
+    return { items, total: headers["x-total"] ?? items.length };
+  }
+
+  /** Register work hours against an assignment. */
+  async createWorkDay(form: WorkDayForm): Promise<WorkDay> {
+    const res = await this.wire.PostWorkDay({ body: form });
+    if (res.status !== 200) {
+      throw new WorkdayApiError(`Unexpected response creating work day (HTTP ${res.status}).`, res.status);
+    }
+    return res.body;
+  }
+
+  // ── Sick hours ───────────────────────────────────────────────────────────
+
+  /** List a person's sick-hour entries. */
+  async listSickDays(personId: string, size: number): Promise<{ items: SickDay[]; total: number }> {
+    const { body: items, headers } = await this.wire.GetSickDayAll({
+      personId,
+      page: 0,
+      size,
+      sort: undefined,
+    });
+    return { items, total: headers["x-total"] ?? items.length };
+  }
+
+  /** Register sick hours for a person. */
+  async createSickDay(form: SickDayForm): Promise<SickDay> {
+    const res = await this.wire.PostSickDay({ body: form });
+    if (res.status !== 200) {
+      throw new WorkdayApiError(`Unexpected response creating sick day (HTTP ${res.status}).`, res.status);
+    }
+    return res.body;
+  }
+
+  // ── Leave hours ──────────────────────────────────────────────────────────
+
+  /** List a person's leave-hour entries. */
+  async listLeaveDays(personId: string, size: number): Promise<{ items: LeaveDay[]; total: number }> {
+    const { body: items, headers } = await this.wire.GetLeaveDayAll({
+      personId,
+      page: 0,
+      size,
+      sort: undefined,
+    });
+    return { items, total: headers["x-total"] ?? items.length };
+  }
+
+  /** Register leave hours for a person. */
+  async createLeaveDay(form: LeaveDayForm): Promise<LeaveDay> {
+    const res = await this.wire.PostLeaveDay({ body: form });
+    if (res.status !== 200) {
+      throw new WorkdayApiError(`Unexpected response creating leave day (HTTP ${res.status}).`, res.status);
+    }
+    return res.body;
+  }
+
+  // ── Assignments ──────────────────────────────────────────────────────────
+
+  /** List a person's assignments — used to find an `assignmentCode` for work hours. */
+  async listAssignments(personId: string, size: number): Promise<{ items: Assignment[]; total: number }> {
+    const { body: items, headers } = await this.wire.GetAssignmentAll({
+      personId,
+      projectCode: undefined,
+      to: undefined,
+      page: 0,
+      size,
+      sort: undefined,
+    });
+    return { items, total: headers["x-total"] ?? items.length };
+  }
 }
 
 function describeStatus(status: number, path: string): string {
@@ -178,7 +271,7 @@ function describeStatus(status: number, path: string): string {
     case 401:
       return "Unauthorized (401): the API key is missing or invalid.";
     case 403:
-      return "Forbidden (403): the API key's user lacks the required authority (listing expenses needs ExpenseAuthority.READ; creating expenses and uploading files need ExpenseAuthority.WRITE).";
+      return "Forbidden (403): the API key's user lacks the authority required for this operation (read operations need the matching *Authority.READ — e.g. WorkDayAuthority.READ; create operations need *Authority.WRITE).";
     case 404:
       return `Not found (404) for ${path}.`;
     default:

--- a/workday-mcp/src/index.ts
+++ b/workday-mcp/src/index.ts
@@ -5,7 +5,16 @@ import { z } from "zod";
 import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
 import { WorkdayApiError, WorkdayClient } from "./client.js";
-import type { Expense } from "./wirespec/model/index.js";
+import type {
+  Assignment,
+  Expense,
+  LeaveDay,
+  LeaveDayForm,
+  SickDay,
+  SickDayForm,
+  WorkDay,
+  WorkDayForm,
+} from "./wirespec/model/index.js";
 
 const DEFAULT_LIMIT = 25;
 
@@ -31,10 +40,114 @@ function decodeBase64(input: string): Buffer {
   return Buffer.from(b64, "base64");
 }
 
-const server = new McpServer({
-  name: "workday-mcp",
-  version: "0.1.0",
-});
+/** Render a "from → to" date range, collapsing a single-day range to one date. */
+function formatRange(from?: string, to?: string): string {
+  if (from && to) return from === to ? from : `${from} → ${to}`;
+  return from ?? to ?? "(no date)";
+}
+
+function formatWorkDay(w: WorkDay): string {
+  const a = w.assignment;
+  const assignment = a
+    ? `${a.client?.name ?? "?"}${a.project?.name ? `/${a.project.name}` : ""} [${a.code}]`
+    : "(no assignment)";
+  return `${formatRange(w.from, w.to)}  ${w.hours ?? "?"}h  ${w.status ?? "?"}  ${assignment}  [${w.code}]`;
+}
+
+function formatSickDay(s: SickDay): string {
+  const parts = [`${formatRange(s.from, s.to)}  ${s.hours ?? "?"}h  ${s.status ?? "?"}`];
+  if (s.description) parts.push(`- ${s.description}`);
+  parts.push(`[${s.code}]`);
+  return parts.join("  ");
+}
+
+function formatLeaveDay(l: LeaveDay): string {
+  const parts = [`${formatRange(l.from, l.to)}  ${l.hours ?? "?"}h  ${l.type ?? "?"}  ${l.status ?? "?"}`];
+  if (l.description) parts.push(`- ${l.description}`);
+  parts.push(`[${l.code}]`);
+  return parts.join("  ");
+}
+
+function formatAssignment(a: Assignment): string {
+  const client = a.client?.name ?? "?";
+  const project = a.project?.name ? `/${a.project.name}` : "";
+  const role = a.role ? ` (${a.role})` : "";
+  return `${client}${project}${role}  ${formatRange(a.from, a.to)}  ${a.hoursPerWeek ?? "?"}h/week  [${a.code}]`;
+}
+
+// Shared input-schema fragments, mirrored across the day tools.
+const limitSchema = z
+  .number()
+  .int()
+  .positive()
+  .max(200)
+  .optional()
+  .describe(`Maximum number of entries to return (default ${DEFAULT_LIMIT}).`);
+const personIdSchema = z
+  .string()
+  .uuid()
+  .optional()
+  .describe("Override person UUID. Defaults to the API key owner (resolved via /api/persons/me).");
+const dateSchema = (which: "start" | "end") =>
+  z.string().describe(`The ${which} date in ISO format YYYY-MM-DD, e.g. 2026-05-20.`);
+const hoursSchema = z
+  .number()
+  .positive()
+  .describe("Total hours for the period (spread evenly across working days unless `days` is given).");
+const daysSchema = z
+  .array(z.number())
+  .optional()
+  .describe(
+    "Optional per-day hours, one entry per calendar day from `from` to `to` (use 0 for non-working days). " +
+      "Overrides the even spread of `hours`.",
+  );
+
+/** Wrap a handler so thrown WorkdayApiErrors (and anything else) become an MCP error result. */
+async function toolResult(
+  build: () => Promise<{ content: { type: "text"; text: string }[] }>,
+): Promise<{ content: { type: "text"; text: string }[]; isError?: boolean }> {
+  try {
+    return await build();
+  } catch (err) {
+    const message =
+      err instanceof WorkdayApiError ? err.message : `Unexpected error: ${(err as Error).message}`;
+    return { isError: true, content: [{ type: "text", text: message }] };
+  }
+}
+
+/** Standard two-block result: a human-readable summary plus the raw JSON. */
+function summaryWithJson(summary: string, raw: unknown): { content: { type: "text"; text: string }[] } {
+  return {
+    content: [
+      { type: "text", text: summary },
+      { type: "text", text: `Raw JSON:\n${JSON.stringify(raw, null, 2)}` },
+    ],
+  };
+}
+
+const server = new McpServer(
+  {
+    name: "workday-mcp",
+    version: "0.1.0",
+  },
+  {
+    instructions: [
+      "This server manages a person's expenses and their work, sick, and leave hours in Flock Workday.",
+      "All tools default to the person who owns the configured API key; an admin may pass an explicit",
+      "`personId`. Dates are ISO `YYYY-MM-DD`. New entries are always submitted with status REQUESTED;",
+      "do not promise approval.",
+      "",
+      "Registering work hours — for a smooth experience, before calling `register_work_hours`:",
+      "  1. Call `list_work_hours` to find the person's most recent entry and reuse the SAME",
+      "     `assignmentCode` by default (people almost always log against their current assignment).",
+      "  2. If there is no prior entry (or the user wants a different one), call `list_assignments`",
+      "     and pick an active assignment, asking the user which one if there is more than one.",
+      "  3. Propose the assignment, date range, and hours back to the user and confirm before submitting.",
+      "Sick and leave hours attach directly to the person, so they need no assignment.",
+      "After registering, you may call the matching list tool to show the user the saved entry.",
+    ].join("\n"),
+  },
+);
 
 server.registerTool(
   "list_expenses",
@@ -215,6 +328,225 @@ server.registerTool(
       };
     }
   },
+);
+
+// ── Work hours ───────────────────────────────────────────────────────────────
+
+server.registerTool(
+  "list_work_hours",
+  {
+    title: "List work hours",
+    description:
+      "List registered work-hour entries from flock-eco-workday, most recent first. Defaults to the " +
+      "API key owner; admins can pass a personId. Each entry shows its date range, hours, status, and " +
+      "the assignment it was logged against (with its assignmentCode in [brackets]). Useful before " +
+      "registering new work hours, to reuse the most recent assignmentCode. Needs WorkDayAuthority.READ.",
+    inputSchema: { limit: limitSchema, personId: personIdSchema },
+  },
+  ({ limit, personId }) =>
+    toolResult(async () => {
+      const client = new WorkdayClient();
+      const resolvedPersonId = personId ?? (await client.getMyPersonId());
+      const { items, total } = await client.listWorkDays(resolvedPersonId, limit ?? DEFAULT_LIMIT);
+      const header =
+        `Found ${total} work-hour entr${total === 1 ? "y" : "ies"} for person ${resolvedPersonId}` +
+        (items.length < total ? `, showing ${items.length}:` : ":");
+      const summary = [header, ...items.map((w) => `• ${formatWorkDay(w)}`)].join("\n");
+      return summaryWithJson(summary, items);
+    }),
+);
+
+server.registerTool(
+  "register_work_hours",
+  {
+    title: "Register work hours",
+    description:
+      "Register work hours against an assignment in flock-eco-workday. Work hours always belong to an " +
+      "assignment, so an `assignmentCode` is required. Before calling this, prefer calling " +
+      "`list_work_hours` first and reuse the assignmentCode of the most recent entry (confirm with the " +
+      "user); if there is none, use `list_assignments` to find one. Provide `from`/`to` (YYYY-MM-DD; " +
+      "use the same date for a single day) and total `hours`, or pass `days` for per-day hours. Defaults " +
+      "to the API key owner; admins can pass a personId. Submitted with status REQUESTED. Needs " +
+      "WorkDayAuthority.WRITE.",
+    inputSchema: {
+      assignmentCode: z
+        .string()
+        .describe("Code of the assignment to log against (from list_work_hours or list_assignments)."),
+      from: dateSchema("start"),
+      to: dateSchema("end"),
+      hours: hoursSchema,
+      days: daysSchema,
+      personId: personIdSchema,
+    },
+  },
+  ({ assignmentCode, from, to, hours, days, personId }) =>
+    toolResult(async () => {
+      const client = new WorkdayClient();
+      // personId is resolved for parity with the other tools / admin overrides, even though the
+      // backend derives ownership from the assignment.
+      if (!personId) await client.getMyPersonId();
+      const form: WorkDayForm = {
+        from,
+        to,
+        hours,
+        days,
+        status: "REQUESTED",
+        assignmentCode,
+        sheets: undefined,
+      };
+      const created = await client.createWorkDay(form);
+      return summaryWithJson(`Registered work hours:\n• ${formatWorkDay(created)}`, created);
+    }),
+);
+
+server.registerTool(
+  "list_assignments",
+  {
+    title: "List assignments",
+    description:
+      "List a person's assignments in flock-eco-workday — used to find the `assignmentCode` needed to " +
+      "register work hours. Each entry shows the client/project, role, date range, hours per week, and " +
+      "the assignmentCode in [brackets]. Defaults to the API key owner; admins can pass a personId. " +
+      "Needs AssignmentAuthority.READ.",
+    inputSchema: { limit: limitSchema, personId: personIdSchema },
+  },
+  ({ limit, personId }) =>
+    toolResult(async () => {
+      const client = new WorkdayClient();
+      const resolvedPersonId = personId ?? (await client.getMyPersonId());
+      const { items, total } = await client.listAssignments(resolvedPersonId, limit ?? DEFAULT_LIMIT);
+      const header =
+        `Found ${total} assignment(s) for person ${resolvedPersonId}` +
+        (items.length < total ? `, showing ${items.length}:` : ":");
+      const summary = [header, ...items.map((a) => `• ${formatAssignment(a)}`)].join("\n");
+      return summaryWithJson(summary, items);
+    }),
+);
+
+// ── Sick hours ─────────────────────────────────────────────────────────────────
+
+server.registerTool(
+  "list_sick_hours",
+  {
+    title: "List sick hours",
+    description:
+      "List registered sick-hour entries from flock-eco-workday, most recent first. Defaults to the API " +
+      "key owner; admins can pass a personId. Needs SickdayAuthority.READ.",
+    inputSchema: { limit: limitSchema, personId: personIdSchema },
+  },
+  ({ limit, personId }) =>
+    toolResult(async () => {
+      const client = new WorkdayClient();
+      const resolvedPersonId = personId ?? (await client.getMyPersonId());
+      const { items, total } = await client.listSickDays(resolvedPersonId, limit ?? DEFAULT_LIMIT);
+      const header =
+        `Found ${total} sick-hour entr${total === 1 ? "y" : "ies"} for person ${resolvedPersonId}` +
+        (items.length < total ? `, showing ${items.length}:` : ":");
+      const summary = [header, ...items.map((s) => `• ${formatSickDay(s)}`)].join("\n");
+      return summaryWithJson(summary, items);
+    }),
+);
+
+server.registerTool(
+  "register_sick_hours",
+  {
+    title: "Register sick hours",
+    description:
+      "Register sick hours for a person in flock-eco-workday. Sick hours attach directly to the person, " +
+      "so no assignment is needed. Provide `from`/`to` (YYYY-MM-DD; same date for a single day) and total " +
+      "`hours`, or pass `days` for per-day hours, plus an optional `description`. Defaults to the API key " +
+      "owner; admins can pass a personId. Submitted with status REQUESTED. Needs SickdayAuthority.WRITE.",
+    inputSchema: {
+      from: dateSchema("start"),
+      to: dateSchema("end"),
+      hours: hoursSchema,
+      days: daysSchema,
+      description: z.string().optional().describe("Optional note, e.g. 'flu'."),
+      personId: personIdSchema,
+    },
+  },
+  ({ from, to, hours, days, description, personId }) =>
+    toolResult(async () => {
+      const client = new WorkdayClient();
+      const resolvedPersonId = personId ?? (await client.getMyPersonId());
+      const form: SickDayForm = {
+        from,
+        to,
+        hours,
+        days,
+        status: "REQUESTED",
+        description,
+        personId: resolvedPersonId,
+      };
+      const created = await client.createSickDay(form);
+      return summaryWithJson(`Registered sick hours:\n• ${formatSickDay(created)}`, created);
+    }),
+);
+
+// ── Leave hours ──────────────────────────────────────────────────────────────
+
+server.registerTool(
+  "list_leave_hours",
+  {
+    title: "List leave hours",
+    description:
+      "List registered leave-hour entries (holiday and other leave) from flock-eco-workday, most recent " +
+      "first. Defaults to the API key owner; admins can pass a personId. Needs LeaveDayAuthority.READ.",
+    inputSchema: { limit: limitSchema, personId: personIdSchema },
+  },
+  ({ limit, personId }) =>
+    toolResult(async () => {
+      const client = new WorkdayClient();
+      const resolvedPersonId = personId ?? (await client.getMyPersonId());
+      const { items, total } = await client.listLeaveDays(resolvedPersonId, limit ?? DEFAULT_LIMIT);
+      const header =
+        `Found ${total} leave-hour entr${total === 1 ? "y" : "ies"} for person ${resolvedPersonId}` +
+        (items.length < total ? `, showing ${items.length}:` : ":");
+      const summary = [header, ...items.map((l) => `• ${formatLeaveDay(l)}`)].join("\n");
+      return summaryWithJson(summary, items);
+    }),
+);
+
+server.registerTool(
+  "register_leave_hours",
+  {
+    title: "Register leave hours",
+    description:
+      "Register leave hours (holiday or other leave) for a person in flock-eco-workday. Leave hours attach " +
+      "directly to the person, so no assignment is needed. Provide a `description`, `from`/`to` " +
+      "(YYYY-MM-DD; same date for a single day) and total `hours`, or pass `days` for per-day hours. " +
+      "`type` defaults to HOLIDAY. Defaults to the API key owner; admins can pass a personId. Submitted " +
+      "with status REQUESTED. Needs LeaveDayAuthority.WRITE.",
+    inputSchema: {
+      description: z.string().min(1).describe("Short description of the leave, e.g. 'Summer holiday'."),
+      from: dateSchema("start"),
+      to: dateSchema("end"),
+      hours: hoursSchema,
+      days: daysSchema,
+      type: z
+        .enum(["HOLIDAY", "PLUSDAY", "PAID_PARENTAL_LEAVE", "UNPAID_PARENTAL_LEAVE", "PAID_LEAVE"])
+        .optional()
+        .describe("Kind of leave. Defaults to HOLIDAY."),
+      personId: personIdSchema,
+    },
+  },
+  ({ description, from, to, hours, days, type, personId }) =>
+    toolResult(async () => {
+      const client = new WorkdayClient();
+      const resolvedPersonId = personId ?? (await client.getMyPersonId());
+      const form: LeaveDayForm = {
+        description,
+        from,
+        to,
+        hours,
+        days,
+        status: "REQUESTED",
+        type: type ?? "HOLIDAY",
+        personId: resolvedPersonId,
+      };
+      const created = await client.createLeaveDay(form);
+      return summaryWithJson(`Registered leave hours:\n• ${formatLeaveDay(created)}`, created);
+    }),
 );
 
 async function main(): Promise<void> {


### PR DESCRIPTION
## What

Extends the `workday-mcp` server beyond expenses with **register** and **retrieve** tools for work, sick, and leave hours — so an MCP client (Claude) can manage hours in plain language the same way it already manages expenses.

New tools (all thin wrappers over the existing generated Wirespec client, mirroring the expense tools):

| Tool | Endpoint | Notes |
| --- | --- | --- |
| `list_work_hours` | `GET /api/workdays` | most recent first; shows the assignment each entry was logged against |
| `register_work_hours` | `POST /api/workdays` | requires an `assignmentCode` (work hours attach to an assignment) |
| `list_assignments` | `GET /api/assignments` | helper so the model can discover an `assignmentCode` |
| `list_sick_hours` | `GET /api/sickdays` | |
| `register_sick_hours` | `POST /api/sickdays` | optional `description` |
| `list_leave_hours` | `GET /api/leave-days` | holiday & other leave |
| `register_leave_hours` | `POST /api/leave-days` | `description` + optional `type` (defaults `HOLIDAY`) |

All registrations submit with status `REQUESTED` and default to the API key owner (admins can pass a `personId`), exactly like the expense tools. List tools use the `x-total` header for counts.

## UX guidance (server `instructions`)

Adds a server-level `instructions` string to the `McpServer` constructor (surfaced to the model via the MCP `initialize` response) plus matching per-tool descriptions, so the client guides Claude to:

- call `list_work_hours` first when logging work hours and **reuse the most recent `assignmentCode`** (falling back to `list_assignments`), and
- **confirm the assignment, dates, and hours with the user** before submitting.

## Notes

- Base is `feature/workday-mcp` (where the MCP server lives) — it isn't in `main` yet.
- No backend changes; purely additive TypeScript in `workday-mcp/` reusing existing services via the generated client.
- README and `CLAUDE.md` updated to document the new tools and the `instructions` behavior.

## Verification

- `npm run typecheck` — passes.
- `npm run build` — regenerates the Wirespec client and bundles `dist/` successfully.
- Stdio MCP handshake smoke test confirms all 9 tools register and the server `instructions` are advertised in the `initialize` response.

Not yet exercised end-to-end against a live backend (no API key/instance in CI); the create/list calls go through the same generated client + auth path as the already-working expense tools.

https://claude.ai/code/session_01BDHGDUvpqfujut9eyb5sq1

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDHGDUvpqfujut9eyb5sq1)_