### PR TITLE
Show general events on the workday sheet; hide plusdays

### DIFF
--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/EventController.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/EventController.kt
@@ -4,8 +4,8 @@ import community.flock.eco.workday.api.endpoint.DeleteEvent
 import community.flock.eco.workday.api.endpoint.DeleteEventRating
 import community.flock.eco.workday.api.endpoint.GetEventAll
 import community.flock.eco.workday.api.endpoint.GetEventByCode
-import community.flock.eco.workday.api.endpoint.GetEventHackDays
 import community.flock.eco.workday.api.endpoint.GetEventRatings
+import community.flock.eco.workday.api.endpoint.GetEventsByYear
 import community.flock.eco.workday.api.endpoint.PostEvent
 import community.flock.eco.workday.api.endpoint.PostEventRating
 import community.flock.eco.workday.api.endpoint.PutEvent
@@ -55,7 +55,7 @@ class EventController(
     PostEvent.Handler,
     PutEvent.Handler,
     DeleteEvent.Handler,
-    GetEventHackDays.Handler,
+    GetEventsByYear.Handler,
     SubscribeToEvent.Handler,
     UnsubscribeFromEvent.Handler,
     GetEventRatings.Handler,
@@ -80,14 +80,14 @@ class EventController(
     }
 
     @PreAuthorize("hasAuthority('EventAuthority.SUBSCRIBE')")
-    override suspend fun getEventHackDays(request: GetEventHackDays.Request): GetEventHackDays.Response<*> {
+    override suspend fun getEventsByYear(request: GetEventsByYear.Request): GetEventsByYear.Response<*> {
         val year = request.queries.year ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST, "year is required")
         val projections =
             eventService
-                .findAllHackDaysOf(year)
+                .findAllEventsOf(year)
                 .sortedBy { it.getFrom() }
                 .map { it.externalize() }
-        return GetEventHackDays.Response200(projections)
+        return GetEventsByYear.Response200(projections)
     }
 
     override suspend fun getEventByCode(request: GetEventByCode.Request): GetEventByCode.Response<*> {

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/repository/EventRepository.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/repository/EventRepository.kt
@@ -22,8 +22,7 @@ interface EventRepository : JpaRepository<Event, Long> {
         type = EntityGraph.EntityGraphType.FETCH,
         attributePaths = ["persons"],
     )
-    fun findAllByTypeIsAndFromBetween(
-        type: EventType,
+    fun findAllByFromBetween(
         from: LocalDate,
         to: LocalDate,
     ): Iterable<EventProjection>

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/services/EventService.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/services/EventService.kt
@@ -3,7 +3,6 @@ package community.flock.eco.workday.application.services
 import community.flock.eco.workday.application.forms.EventForm
 import community.flock.eco.workday.application.interfaces.validate
 import community.flock.eco.workday.application.model.Event
-import community.flock.eco.workday.application.model.EventType
 import community.flock.eco.workday.application.model.Person
 import community.flock.eco.workday.application.repository.EventProjection
 import community.flock.eco.workday.application.repository.EventRatingRepository
@@ -35,9 +34,8 @@ class EventService(
 
     fun findByCode(code: String) = eventRepository.findByCode(code).toNullable()
 
-    fun findAllHackDaysOf(year: Int): Iterable<EventProjection> =
-        eventRepository.findAllByTypeIsAndFromBetween(
-            type = EventType.FLOCK_HACK_DAY,
+    fun findAllEventsOf(year: Int): Iterable<EventProjection> =
+        eventRepository.findAllByFromBetween(
             from = LocalDate.of(year, 1, 1),
             to = LocalDate.of(year, 12, 31),
         )

--- a/workday-application/src/main/react/clients/EventClient.ts
+++ b/workday-application/src/main/react/clients/EventClient.ts
@@ -138,15 +138,20 @@ const deleteRatings = (eventCode, personId) => {
     .then((res) => res?.body);
 };
 
-const getHackDays = (year: number): Promise<FlockEvent[]> => {
+const getEventsByYear = (year: number): Promise<FlockEvent[]> => {
   const opts = {
     method: 'GET',
   };
-  return fetch(`${path}/hack-days?year=${year}`, opts)
+  return fetch(`${path}/year?year=${year}`, opts)
     .then((it) => validateResponse<FlockEventRawProjection[]>(it))
     .then((it) => checkResponse(it))
     .then((res) => res?.body.map(internalize));
 };
+
+const getHackDays = (year: number): Promise<FlockEvent[]> =>
+  getEventsByYear(year).then((events) =>
+    events.filter((event) => event.type === EventType.FLOCK_HACK_DAY),
+  );
 
 const subscribeToEvent = (event: FlockEvent) => {
   const opts = {
@@ -180,6 +185,7 @@ export const EventClient = {
   getRatings,
   postRatings,
   deleteRatings,
+  getEventsByYear,
   getHackDays,
   subscribeToEvent,
   unsubscribeFromEvent,

--- a/workday-application/src/main/react/components/inputs/PeriodInput.tsx
+++ b/workday-application/src/main/react/components/inputs/PeriodInput.tsx
@@ -27,7 +27,8 @@ const LEAVE_BG = 'rgba(126, 87, 194, 0.18)';
 
 const backgroundFor = (meta: DayMeta | undefined): string | undefined => {
   if (!meta) return undefined;
-  if (meta.hackday) return HACKDAY_BG;
+  // General events share the hackday colour (green) by request.
+  if (meta.hackday || meta.generalEvent) return HACKDAY_BG;
   if (meta.leave) return LEAVE_BG;
   return undefined;
 };
@@ -36,6 +37,7 @@ const tooltipFor = (meta: DayMeta | undefined): string | undefined => {
   if (!meta) return undefined;
   const parts: string[] = [];
   if (meta.hackday) parts.push(`Hackday: ${meta.hackday.description}`);
+  if (meta.generalEvent) parts.push(`Event: ${meta.generalEvent.description}`);
   if (meta.leave) {
     const label = meta.leave.description ?? meta.leave.type;
     const statusLabel = meta.leave.status === 'REQUESTED' ? ' (requested)' : '';

--- a/workday-application/src/main/react/hooks/DayMetaHook.ts
+++ b/workday-application/src/main/react/hooks/DayMetaHook.ts
@@ -1,6 +1,10 @@
 import dayjs, { type Dayjs } from 'dayjs';
 import { useEffect, useState } from 'react';
-import { EventClient, type FlockEvent } from '../clients/EventClient';
+import {
+  EventClient,
+  EventType,
+  type FlockEvent,
+} from '../clients/EventClient';
 import { LeaveDayClient } from '../clients/LeaveDayClient';
 import { stringifyDate } from '../utils/stringifyDate';
 
@@ -14,6 +18,7 @@ export type LeaveDayType =
 
 export type DayMeta = {
   hackday?: { description: string };
+  generalEvent?: { description: string };
   leave?: {
     type: LeaveDayType;
     status: LeaveDayStatus;
@@ -103,8 +108,8 @@ export function useDayMeta(
 
     let cancelled = false;
 
-    const hackdaysPromise = Promise.all(
-      yearsInRange(from, to).map((year) => EventClient.getHackDays(year)),
+    const eventsPromise = Promise.all(
+      yearsInRange(from, to).map((year) => EventClient.getEventsByYear(year)),
     ).then((pages) =>
       pages
         .flat()
@@ -118,26 +123,34 @@ export function useDayMeta(
       { personId },
     ).then((res) => res.list as unknown as LeaveDayLite[]);
 
-    Promise.all([hackdaysPromise, leavePromise])
-      .then(([hackdays, leaveDays]) => {
+    Promise.all([eventsPromise, leavePromise])
+      .then(([events, leaveDays]) => {
         if (cancelled) return;
 
         const next = new Map<string, DayMeta>();
 
-        for (const event of hackdays) {
+        for (const event of events) {
           const dates = overlapDays(from, to, event.from, event.to);
           for (const date of dates) {
             const key = stringifyDate(date);
             const existing = next.get(key) ?? {};
-            next.set(key, {
-              ...existing,
-              hackday: { description: event.description },
-            });
+            if (event.type === EventType.FLOCK_HACK_DAY) {
+              next.set(key, {
+                ...existing,
+                hackday: { description: event.description },
+              });
+            } else if (event.type === EventType.GENERAL_EVENT) {
+              next.set(key, {
+                ...existing,
+                generalEvent: { description: event.description },
+              });
+            }
           }
         }
 
         for (const leave of leaveDays) {
           if (leave.status === 'REJECTED') continue;
+          if (leave.type === 'PLUSDAY') continue;
           const dates = overlapDays(
             from,
             to,

--- a/workday-application/src/main/wirespec/events.ws
+++ b/workday-application/src/main/wirespec/events.ws
@@ -13,7 +13,7 @@ endpoint PutEvent PUT EventForm /api/events/{code: String} -> {
 endpoint DeleteEvent DELETE /api/events/{code: String} -> {
   204 -> Unit
 }
-endpoint GetEventHackDays GET /api/events/hack-days ? {year: Integer32} -> {
+endpoint GetEventsByYear GET /api/events/year ? {year: Integer32} -> {
   200 -> EventProjection[]
 }
 endpoint SubscribeToEvent PUT /api/events/{eventCode: String}/subscribe -> {

--- a/workday-application/src/test/kotlin/community/flock/eco/workday/controllers/EventControllerTest.kt
+++ b/workday-application/src/test/kotlin/community/flock/eco/workday/controllers/EventControllerTest.kt
@@ -99,7 +99,7 @@ class EventControllerTest : WorkdayIntegrationTest() {
         val communityDay =
             createEvent(LocalDate.of(2023, 6, 2), LocalDate.of(2023, 6, 3), type = EventType.FLOCK_COMMUNITY_DAY)
         val generalEvent =
-            createEvent(LocalDate.of(2023, 12, 31), LocalDate.of(2023, 12, 31), type = EventType.GENERAL_EVENT)
+            createEvent(LocalDate.of(2023, 12, 30), LocalDate.of(2023, 12, 31), type = EventType.GENERAL_EVENT)
 
         mvc
             .perform(
@@ -129,7 +129,7 @@ class EventControllerTest : WorkdayIntegrationTest() {
                       {
                         "type": "GENERAL_EVENT",
                         "code": "${generalEvent.code}",
-                        "from": "2023-12-31",
+                        "from": "2023-12-30",
                         "to": "2023-12-31"
                       }
                     ]

--- a/workday-application/src/test/kotlin/community/flock/eco/workday/controllers/EventControllerTest.kt
+++ b/workday-application/src/test/kotlin/community/flock/eco/workday/controllers/EventControllerTest.kt
@@ -93,14 +93,17 @@ class EventControllerTest : WorkdayIntegrationTest() {
     ).run { eventService.create(this) }
 
     @Test
-    fun `should get hack-day events`() {
-        val event = createEvent(LocalDate.of(2023, 2, 2), LocalDate.of(2023, 2, 3), type = EventType.FLOCK_HACK_DAY)
+    fun `should get all events of a year regardless of type`() {
+        val hackDay = createEvent(LocalDate.of(2023, 2, 2), LocalDate.of(2023, 2, 3), type = EventType.FLOCK_HACK_DAY)
         createEvent(LocalDate.of(2024, 4, 2), LocalDate.of(2024, 4, 3), type = EventType.FLOCK_HACK_DAY)
-        createEvent(LocalDate.of(2023, 6, 2), LocalDate.of(2023, 6, 3), type = EventType.FLOCK_COMMUNITY_DAY)
+        val communityDay =
+            createEvent(LocalDate.of(2023, 6, 2), LocalDate.of(2023, 6, 3), type = EventType.FLOCK_COMMUNITY_DAY)
+        val generalEvent =
+            createEvent(LocalDate.of(2023, 12, 31), LocalDate.of(2023, 12, 31), type = EventType.GENERAL_EVENT)
 
         mvc
             .perform(
-                get("$baseUrl/hack-days?year=2023")
+                get("$baseUrl/year?year=2023")
                     .with(SecurityMockMvcRequestPostProcessors.user(createUser(adminAuthorities)))
                     .accept(MediaType.APPLICATION_JSON),
             ).asyncDispatch()
@@ -112,11 +115,22 @@ class EventControllerTest : WorkdayIntegrationTest() {
                     """
                     [
                       {
-                        "description": "Henk",
-                        "code": "${event.code}",
+                        "type": "FLOCK_HACK_DAY",
+                        "code": "${hackDay.code}",
                         "from": "2023-02-02",
-                        "to": "2023-02-03",
-                        "persons": []
+                        "to": "2023-02-03"
+                      },
+                      {
+                        "type": "FLOCK_COMMUNITY_DAY",
+                        "code": "${communityDay.code}",
+                        "from": "2023-06-02",
+                        "to": "2023-06-03"
+                      },
+                      {
+                        "type": "GENERAL_EVENT",
+                        "code": "${generalEvent.code}",
+                        "from": "2023-12-31",
+                        "to": "2023-12-31"
                       }
                     ]
                     """.trimIndent(),


### PR DESCRIPTION
## Summary

Three changes to the workday day-grid soft-warn (`useDayMeta`), which previously only surfaced hackdays and leave days:

1. **General events on the workday sheet** — `GENERAL_EVENT`s the person attends now tint their days the same green as hackdays, with an `Event: <description>` tooltip. (Original report: *"I do not see general events in my workday overview"*.)

2. **Generic events-by-year endpoint, reused for hackdays** — replaced the hackday-specific `GET /api/events/hack-days` with a generic `GET /api/events/year?year=` that returns every event of a calendar year. Hackdays and general events are now both derived from this single fetch by filtering on `type`. Frontend `getHackDays` is a thin wrapper over `getEventsByYear`, so `HackDayEventsCard` is unchanged.

3. **Hide plusdays** — `PLUSDAY` leave is excluded from the workday sheet. Plusdays are time-for-time compensation, not an absence, so they shouldn't show as a conflict.

## Files

**Backend**
- `events.ws` — `GetEventHackDays` → `GetEventsByYear`
- `EventRepository.kt` — `findAllByTypeIsAndFromBetween` → `findAllByFromBetween`
- `EventService.kt` — `findAllHackDaysOf` → `findAllEventsOf`
- `EventController.kt` — `getEventHackDays` → `getEventsByYear` (same `SUBSCRIBE` authority)
- `EventControllerTest.kt` — asserts the year endpoint returns all event types for the year

**Frontend**
- `EventClient.ts` — `getEventsByYear`; `getHackDays` now wraps it
- `DayMetaHook.ts` — single events fetch deriving hackday + generalEvent meta; excludes `PLUSDAY` leave
- `PeriodInput.tsx` — general-event days get the hackday green + tooltip

## Verification

- `npm test` (jest): 25/25 pass
- `tsc --noEmit`: clean on changed files
- `biome check`: clean on changed files
- `npm run generate`: regenerates the `GetEventsByYear` contract

⚠️ **Backend test not run locally:** `workday-application` doesn't compile in my local environment due to a pre-existing wirespec 0.18.13 codegen issue with the `UserAccount` inheritance types (reproduces on a clean `main`, unrelated to this change). Relying on CI to run `EventControllerTest`.

### Note for reviewers
The generic `/year` endpoint now returns **all** event types for the year (conferences, community days, etc.) to any `SUBSCRIBE` user, whereas before only hackdays were exposed this way. Same projection shape that was already public for hackdays — flag if any type's description/attendees are considered sensitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)