### PR TITLE
feat: serve leave-day-report-me aggregation endpoint

### DIFF
--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/AggregationController.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/AggregationController.kt
@@ -6,6 +6,7 @@ import community.flock.eco.workday.api.endpoint.HolidayDetailsMeYear
 import community.flock.eco.workday.api.endpoint.HourAssignmentClientOverviewEmployee
 import community.flock.eco.workday.api.endpoint.HourClientOverviewEmployee
 import community.flock.eco.workday.api.endpoint.LeaveDayReportByYear
+import community.flock.eco.workday.api.endpoint.LeaveDayReportMeByYear
 import community.flock.eco.workday.api.endpoint.PersonNonProductiveHoursPerDay
 import community.flock.eco.workday.api.endpoint.RevenuePerClientByYear
 import community.flock.eco.workday.api.endpoint.TotalsPerMonthByYear
@@ -56,6 +57,7 @@ interface AggregationHandler :
     TotalsPerPersonByYear_1.Handler,
     TotalsPerMonthByYear.Handler,
     LeaveDayReportByYear.Handler,
+    LeaveDayReportMeByYear.Handler,
     HackDayReportByYear.Handler,
     HourClientOverviewEmployee.Handler,
     HourAssignmentClientOverviewEmployee.Handler,
@@ -121,6 +123,16 @@ class AggregationController(
         LeaveDayReportByYear.Response200(
             aggregationService.leaveDayReport(request.queries.year).map { it.produce() },
         )
+
+    @PreAuthorize("isAuthenticated()")
+    override suspend fun leaveDayReportMeByYear(request: LeaveDayReportMeByYear.Request): LeaveDayReportMeByYear.Response<*> {
+        val person =
+            personService.findByUserCode(authentication().name)
+                ?: throw ResponseStatusException(HttpStatus.FORBIDDEN)
+        return LeaveDayReportMeByYear.Response200(
+            aggregationService.leaveDayReportMe(request.queries.year, person).produce(),
+        )
+    }
 
     @PreAuthorize("hasAuthority('AggregationAuthority.READ')")
     override suspend fun hackDayReportByYear(request: HackDayReportByYear.Request): HackDayReportByYear.Response<*> =

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/services/AggregationService.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/services/AggregationService.kt
@@ -122,43 +122,60 @@ class AggregationService(
         val all = dataService.findAllData(from, to)
         return all
             .allPersons()
-            .map { person ->
-                AggregationLeaveDay(
-                    name = person.getFullName(),
-                    contractHours =
-                        all.contract
-                            .filterIsInstance<ContractInternal>()
-                            .filter { it.person == person }
-                            .map { it.totalLeaveDayHoursInPeriod(period) }
-                            .sum(),
-                    plusHours =
-                        all.leaveDay
-                            .filter { it.type == LeaveDayType.PLUSDAY }
-                            .filter { it.person == person }
-                            .totalHoursInPeriod(from, to),
-                    holidayHours =
-                        all.leaveDay
-                            .filter { it.type == LeaveDayType.HOLIDAY }
-                            .filter { it.person == person }
-                            .totalHoursInPeriod(from, to),
-                    paidParentalLeaveHours =
-                        all.leaveDay
-                            .filter { it.person == person }
-                            .filter { it.type == LeaveDayType.PAID_PARENTAL_LEAVE }
-                            .totalHoursInPeriod(from, to),
-                    unpaidParentalLeaveHours =
-                        all.leaveDay
-                            .filter { it.person == person }
-                            .filter { it.type == LeaveDayType.UNPAID_PARENTAL_LEAVE }
-                            .totalHoursInPeriod(from, to),
-                    paidLeaveHours =
-                        all.leaveDay
-                            .filter { it.person == person }
-                            .filter { it.type == LeaveDayType.PAID_LEAVE }
-                            .totalHoursInPeriod(from, to),
-                )
-            }
+            .map { person -> personLeaveDay(person, all, period, from, to) }
     }
+
+    fun leaveDayReportMe(
+        year: Int,
+        person: Person,
+    ): AggregationLeaveDay {
+        val from = YearMonth.of(year, 1).atDay(1)
+        val to = YearMonth.of(year, 12).atEndOfMonth()
+        val period = FromToPeriod(from, to)
+        val data = dataService.findAllData(from, to, person.uuid)
+        return personLeaveDay(person, data, period, from, to)
+    }
+
+    private fun personLeaveDay(
+        person: Person,
+        data: Data,
+        period: FromToPeriod,
+        from: LocalDate,
+        to: LocalDate,
+    ) = AggregationLeaveDay(
+        name = person.getFullName(),
+        contractHours =
+            data.contract
+                .filterIsInstance<ContractInternal>()
+                .filter { it.person == person }
+                .map { it.totalLeaveDayHoursInPeriod(period) }
+                .sum(),
+        plusHours =
+            data.leaveDay
+                .filter { it.type == LeaveDayType.PLUSDAY }
+                .filter { it.person == person }
+                .totalHoursInPeriod(from, to),
+        holidayHours =
+            data.leaveDay
+                .filter { it.type == LeaveDayType.HOLIDAY }
+                .filter { it.person == person }
+                .totalHoursInPeriod(from, to),
+        paidParentalLeaveHours =
+            data.leaveDay
+                .filter { it.person == person }
+                .filter { it.type == LeaveDayType.PAID_PARENTAL_LEAVE }
+                .totalHoursInPeriod(from, to),
+        unpaidParentalLeaveHours =
+            data.leaveDay
+                .filter { it.person == person }
+                .filter { it.type == LeaveDayType.UNPAID_PARENTAL_LEAVE }
+                .totalHoursInPeriod(from, to),
+        paidLeaveHours =
+            data.leaveDay
+                .filter { it.person == person }
+                .filter { it.type == LeaveDayType.PAID_LEAVE }
+                .totalHoursInPeriod(from, to),
+    )
 
     fun hackdayReport(year: Int): List<AggregationHackDay> {
         val from = YearMonth.of(year, 1).atDay(1)

--- a/workday-application/src/test/kotlin/community/flock/eco/workday/controllers/AggregationControllerTest.kt
+++ b/workday-application/src/test/kotlin/community/flock/eco/workday/controllers/AggregationControllerTest.kt
@@ -289,6 +289,41 @@ class AggregationControllerTest(
     }
 
     @Test
+    fun `should return leave-day report me by year`() {
+        val regularUser = createHelper.createUserEntity(emptySet())
+        val person = createHelper.createPersonEntity("Leave", "Me", regularUser.code)
+        createHelper.createContractInternal(
+            person = person,
+            from = LocalDate.of(2024, 1, 1),
+            to = LocalDate.of(2024, 12, 31),
+        )
+
+        mvc
+            .perform(
+                get("$baseUrl/leave-day-report-me?year=2024")
+                    .with(user(CreateHelper.UserSecurity(regularUser.toDomain())))
+                    .accept(APPLICATION_JSON),
+            ).asyncDispatch()
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(APPLICATION_JSON))
+            .andExpect(jsonPath("$.name").value("Leave Me"))
+            .andExpect(jsonPath("$.contractHours").exists())
+    }
+
+    @Test
+    fun `leave-day-report-me should return forbidden when user has no linked person`() {
+        val regularUser = createHelper.createUserEntity(emptySet())
+
+        mvc
+            .perform(
+                get("$baseUrl/leave-day-report-me?year=2024")
+                    .with(user(CreateHelper.UserSecurity(regularUser.toDomain())))
+                    .accept(APPLICATION_JSON),
+            ).asyncDispatch()
+            .andExpect(status().isForbidden)
+    }
+
+    @Test
     fun `holiday-details-me should return forbidden when user has no linked person`() {
         val regularUser = createHelper.createUserEntity(emptySet())
 


### PR DESCRIPTION
## Problem

The **My Year** page (flock-app) calls `GET /api/aggregations/leave-day-report-me?year=…`. The path is declared in the wirespec contract (`aggregations.ws`) and exists in the generated TS/Kotlin sources, but `AggregationController`'s `AggregationHandler` interface never included `LeaveDayReportMeByYear.Handler`, so no route served it.

Unmapped `/api/**` paths fall through to the SPA catch-all in `WebMvcConfig`, which returns `index.html` with **HTTP 200**. The wirespec client treats 200 as success and hands the HTML to the deserializer → deserialization failure → My Year shows an unexpected error.

## Fix (additive, no contract/regen/migration)

- **`AggregationController`**: add `LeaveDayReportMeByYear.Handler` to the handler interface (auto-registers the route via the wirespec Spring integration) and implement `leaveDayReportMeByYear` — `@PreAuthorize("isAuthenticated()")`, resolves the caller via `personService.findByUserCode(...)` (FORBIDDEN if no linked person), mirroring the existing `holidayDetailsMeYear`.
- **`AggregationService`**: add `leaveDayReportMe(year, person)` returning a single `AggregationLeaveDay` for the authenticated person, scoped via `dataService.findAllData(from, to, person.uuid)`. The per-person body previously inline in `leaveDayReport` is extracted into a shared private `personLeaveDay` helper so the list and `me` variants can't drift.

The generated wirespec handler already existed — no `.ws` edit, no `npm run generate`, no DB migration, no security-config change.

## Tests

Two controller tests added (mirroring the `holiday-details-me` pattern): a `me` happy-path asserting JSON (not HTML) and a forbidden-when-no-linked-person case. Full `workday-application` suite passes except a pre-existing, locale-dependent failure in `WorkdayEmailServiceTest` ("January" vs Dutch "januari"), unrelated to this change and failing on `main` as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)