### PR TITLE
ci: auto-deploy production to Cloud Run after approval

### DIFF
--- a/.github/workflows/gcp.yml
+++ b/.github/workflows/gcp.yml
@@ -314,3 +314,10 @@ jobs:
 
       - name: Build and Deploy
         run: ./mvnw -B clean package jib:build -DskipTests -Pfrontend -Dnpm.ci.skip -Djib.to.image=eu.gcr.io/flock-community/flock-eco-workday -Djib.to.tags=${{ github.sha }} --file pom.xml
+
+      - name: Deploy image to Cloud Run (production)
+        run: |
+          gcloud run deploy workday-app \
+            --image eu.gcr.io/flock-community/flock-eco-workday:${{ github.sha }} \
+            --region europe-west1 \
+            --project flock-community


### PR DESCRIPTION
## What

Adds a `gcloud run deploy` step to the approval-gated `deploy-production` job so an approved run actually promotes the freshly-built image to the running `workday-app` Cloud Run service — automatically, instead of via a manual deploy.

## Why

The `deploy-production` job (added in #499) only ran `jib:build`, which **pushes** the image to `eu.gcr.io/flock-community/flock-eco-workday`. Promoting that image to the live revision was still a manual `gcloud run deploy`. This closes that last manual step while keeping the human approval gate.

## How it works

1. Push to `main` → develop builds & deploys as before.
2. `deploy-production` pauses on the `production` GitHub environment's required-reviewer gate.
3. After approval: jib pushes `…/flock-eco-workday:${{ github.sha }}`, then the new step runs:
   ```
   gcloud run deploy workday-app \
     --image eu.gcr.io/flock-community/flock-eco-workday:${SHA} \
     --region europe-west1 --project flock-community
   ```

### Properties
- **Image-only deploy** — passes only `--image`, preserving the service's existing env/secrets/config.
- **Pinned to commit SHA** — traceable, not the mutable `:latest`.
- **Approval-gated** — runs only inside the existing `production`-environment job.
- `gcloud` + GCP auth are already set up earlier in the job.

## Before first run — verify
- [ ] Required reviewers are configured under **Settings → Environments → production** (the gate only pauses if reviewers are set).
- [ ] The WIF service account (`GCP_SA_EMAIL`) has `roles/run.developer` on `workday-app` and `iam.serviceAccountUser` on the runtime SA. Manual deploys likely used personal creds, so the CI SA may need these granted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)