### PR TITLE
Let event subscribers list events

### DIFF
--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/EventController.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/EventController.kt
@@ -65,7 +65,9 @@ class EventController(
         SecurityContextHolder.getContext().authentication
             ?: throw ResponseStatusException(HttpStatus.UNAUTHORIZED)
 
-    @PreAuthorize("hasAuthority('EventAuthority.READ')")
+    // SUBSCRIBE-only workers (the default employee authority set) may list events too:
+    // redact() below strips everything a non-attendee may not see.
+    @PreAuthorize("hasAnyAuthority('EventAuthority.READ', 'EventAuthority.SUBSCRIBE')")
     override suspend fun getEventAll(request: GetEventAll.Request): GetEventAll.Response<*> {
         val auth = authentication()
         val page = eventService.findAll(request.queries.toPageable())

--- a/workday-application/src/test/kotlin/community/flock/eco/workday/controllers/EventControllerTest.kt
+++ b/workday-application/src/test/kotlin/community/flock/eco/workday/controllers/EventControllerTest.kt
@@ -180,6 +180,25 @@ class EventControllerTest : WorkdayIntegrationTest() {
     }
 
     @Test
+    fun `Worker with only SUBSCRIBE authority can list events, redacted when not attending`() {
+        createEvent(LocalDate.of(2023, 2, 2), LocalDate.of(2023, 2, 3))
+        val user = createUser(setOf("EventAuthority.SUBSCRIBE"))
+
+        mvc
+            .perform(
+                get(baseUrl)
+                    .with(SecurityMockMvcRequestPostProcessors.user(user))
+                    .accept(MediaType.APPLICATION_JSON),
+            ).asyncDispatch()
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(MockMvcResultMatchers.jsonPath("\$[0].description").value("N/A - Henk"))
+            .andExpect(MockMvcResultMatchers.jsonPath("\$[0].persons.length()").value(0))
+            .andExpect(MockMvcResultMatchers.jsonPath("\$[0].costs").value(0.0))
+            .andExpect(MockMvcResultMatchers.jsonPath("\$[0].days").doesNotExist())
+    }
+
+    @Test
     fun `User needs the right EventAuthority`() {
         val event = createEvent(LocalDate.of(2023, 2, 2), LocalDate.of(2023, 2, 3))
         val user = createUser(setOf("EventAuthority.READ", "EventAuthority.WRITE", "EventAuthority.ADMIN"))


### PR DESCRIPTION
Relaxes `getEventAll` to accept `EventAuthority.SUBSCRIBE` next to `READ`.

Employees are provisioned with `SUBSCRIBE` but not `READ` (the `UserForm` default authority preset), so the mobile app's events screen hit a 403 on `GET /api/events`. The web frontend never surfaced this: the drawer hides the Events page for users without `READ`.

Safe to open up because `redact()` already strips everything a non-attendee may not see — and `GET /api/events/year` already hands `SUBSCRIBE` holders unredacted events anyway, so this widens nothing in practice. Regression test included (SUBSCRIBE-only user → 200 with redacted description, persons, costs, days).

<details>
<summary>Pre-existing issues spotted while reviewing (not addressed here)</summary>

- `GET /api/events/year` is `SUBSCRIBE`-gated but returns **unredacted** descriptions + person rosters — bypasses the redaction `getEventAll` applies.
- `getEventByCode` throws **401** (not 403) for authenticated non-attendees via `applyAuthentication()`.
- `postEventRating` / `deleteEventRating` have no authority check at all — any authenticated user can mutate ratings.
- The comment in `subscribeToEvent` claiming `@PreAuthorize` is not enforced on Wirespec handler overrides appears stale — it is enforced; in MockMvc the denial only shows after `asyncDispatch()`.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)