### PR TITLE
build(deps): upgrade yup 0.27 → 1.x (migrate 17 form schemas)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "recharts": "^2.0.3",
         "sass": "^1.69.4",
         "styled-components": "^6.1.0",
-        "yup": "^0.27.0"
+        "yup": "^1.7.1"
       },
       "devDependencies": {
         "@biomejs/biome": "2.3.10",
@@ -4948,15 +4948,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/fn-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
-      "integrity": "sha512-oIDB1rXf3BUnn00bh2jVM0byuqr94rBh6g7ZfdKcbmp1we2GQtPzKdloyvBXHs+q3fvxB8EqX5ecFba3RwCSjA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -7815,9 +7806,9 @@
       }
     },
     "node_modules/property-expr": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-1.5.1.tgz",
-      "integrity": "sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
       "license": "MIT"
     },
     "node_modules/psl": {
@@ -8726,12 +8717,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/synchronous-promise": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.17.tgz",
-      "integrity": "sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -8752,6 +8737,12 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
       "license": "MIT"
     },
     "node_modules/tiny-invariant": {
@@ -8911,6 +8902,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript": {
@@ -9367,17 +9370,15 @@
       }
     },
     "node_modules/yup": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-0.27.0.tgz",
-      "integrity": "sha512-v1yFnE4+u9za42gG/b/081E7uNW9mUj3qtkmelLbW5YPROZzSH/KUUyJu9Wt8vxFJcT9otL/eZopS0YK1L5yPQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.7.1.tgz",
+      "integrity": "sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "fn-name": "~2.0.1",
-        "lodash": "^4.17.11",
-        "property-expr": "^1.5.0",
-        "synchronous-promise": "^2.0.6",
-        "toposort": "^2.0.2"
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "recharts": "^2.0.3",
     "sass": "^1.69.4",
     "styled-components": "^6.1.0",
-    "yup": "^0.27.0"
+    "yup": "^1.7.1"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.10",

--- a/workday-application/src/main/react/features/assignments/AssignmentForm.tsx
+++ b/workday-application/src/main/react/features/assignments/AssignmentForm.tsx
@@ -122,7 +122,15 @@ export const AssignmentForm = ({ value, onSubmit }: AssignmentFormProps) => {
   return (
     <>
       <Formik
-        initialValues={{ ...ASSIGNMENT_FORM_SCHEMA.cast(), ...init }}
+        // Form fields hold Dayjs dates that convert to the wire AssignmentRequest
+        // (string dates) at the submit boundary. yup 1.x types getDefault() (cast()
+        // was untyped before), so assert the in-form shape here.
+        initialValues={
+          {
+            ...ASSIGNMENT_FORM_SCHEMA.getDefault(),
+            ...init,
+          } as unknown as AssignmentRequest
+        }
         onSubmit={onSubmit}
         validationSchema={ASSIGNMENT_FORM_SCHEMA}
         enableReinitialize

--- a/workday-application/src/main/react/features/client/ClientForm.tsx
+++ b/workday-application/src/main/react/features/client/ClientForm.tsx
@@ -46,7 +46,7 @@ export function ClientForm({ code, value, onSubmit }: ClientFormProps) {
 
   return (
     <Formik
-      initialValues={{ ...schema.cast(), ...state }}
+      initialValues={{ ...schema.getDefault(), ...state }}
       onSubmit={handleSubmit}
       validationSchema={schema}
       enableReinitialize

--- a/workday-application/src/main/react/features/contract/ContractFormExternal.tsx
+++ b/workday-application/src/main/react/features/contract/ContractFormExternal.tsx
@@ -71,7 +71,7 @@ export const ContractFormExternal = ({
 
   return (
     <Formik
-      initialValues={{ ...schema.default(), ...value }}
+      initialValues={{ ...schema.getDefault(), ...value }}
       onSubmit={onSubmit}
       validationSchema={schema}
       enableReinitialize

--- a/workday-application/src/main/react/features/contract/ContractFormInternal.tsx
+++ b/workday-application/src/main/react/features/contract/ContractFormInternal.tsx
@@ -102,7 +102,7 @@ export const ContractFormInternal = ({
 
   return (
     <Formik
-      initialValues={{ ...schema.cast(), ...init }}
+      initialValues={{ ...schema.getDefault(), ...init }}
       onSubmit={onSubmit}
       validationSchema={schema}
       enableReinitialize

--- a/workday-application/src/main/react/features/contract/ContractFormManagement.tsx
+++ b/workday-application/src/main/react/features/contract/ContractFormManagement.tsx
@@ -60,7 +60,7 @@ export const ContractFormManagement = ({
 
   return (
     <Formik
-      initialValues={{ ...schema.cast(), ...init }}
+      initialValues={{ ...schema.getDefault(), ...init }}
       onSubmit={onSubmit}
       validationSchema={schema}
       enableReinitialize

--- a/workday-application/src/main/react/features/contract/ContractFormService.tsx
+++ b/workday-application/src/main/react/features/contract/ContractFormService.tsx
@@ -70,7 +70,7 @@ export const ContractFormService = ({
 
   return (
     <Formik
-      initialValues={{ ...schema.cast(), ...init }}
+      initialValues={{ ...schema.getDefault(), ...init }}
       onSubmit={onSubmit}
       validationSchema={schema}
       enableReinitialize

--- a/workday-application/src/main/react/features/event/EventDialog.tsx
+++ b/workday-application/src/main/react/features/event/EventDialog.tsx
@@ -35,7 +35,7 @@ export function EventDialog({ open, code, onComplete }: EventDialogProps) {
           });
         });
       } else {
-        setState(schema.cast());
+        setState(schema.getDefault());
       }
     } else {
       setState(undefined);

--- a/workday-application/src/main/react/features/event/EventForm.tsx
+++ b/workday-application/src/main/react/features/event/EventForm.tsx
@@ -17,8 +17,8 @@ const now = dayjs();
 
 const schema = Yup.object().shape({
   description: Yup.string().required('Description is required').default(''),
-  from: Yup.date().required('From date is required').default(now),
-  to: Yup.date().required('To date is required').default(now),
+  from: Yup.mixed<dayjs.Dayjs>().required('From date is required').default(now),
+  to: Yup.mixed<dayjs.Dayjs>().required('To date is required').default(now),
   days: Yup.array().default([8]).nullable(),
   personIds: Yup.array().default([]),
   costs: Yup.number().required().min(0).default(0),
@@ -105,7 +105,7 @@ export function EventForm({ value, onSubmit }: EventFormProps) {
     });
   };
 
-  const init = { ...schema.default(), ...mutatePeriod(value) };
+  const init = { ...schema.getDefault(), ...mutatePeriod(value) };
   return (
     value && (
       <Formik

--- a/workday-application/src/main/react/features/expense/ExpenseFormCost.tsx
+++ b/workday-application/src/main/react/features/expense/ExpenseFormCost.tsx
@@ -62,7 +62,7 @@ export const ExpenseFormCost = ({ value, onSubmit }: ExpenseFormCostProps) => {
   return (
     <Formik
       initialValues={{
-        ...schema.cast(),
+        ...schema.getDefault(),
         ...value,
       }}
       onSubmit={onSubmit}

--- a/workday-application/src/main/react/features/expense/ExpenseFormTravel.tsx
+++ b/workday-application/src/main/react/features/expense/ExpenseFormTravel.tsx
@@ -18,8 +18,8 @@ export type ExpenseTravelForm = {
 export const schema = Yup.object({
   description: Yup.string().required().default(''),
   date: Yup.mixed().required().default(dayjs()),
-  distance: Yup.number().required().default(''),
-  allowance: Yup.number().required().default(''),
+  distance: Yup.number().required().default(0),
+  allowance: Yup.number().required().default(0),
 });
 
 type ExpenseFormTravelProps = {
@@ -72,7 +72,7 @@ export const ExpenseFormTravel = ({
   return (
     <Formik
       initialValues={{
-        ...schema.cast(),
+        ...schema.getDefault(),
         ...initialState,
       }}
       onSubmit={onSubmit}

--- a/workday-application/src/main/react/features/holiday/HolidayForm.tsx
+++ b/workday-application/src/main/react/features/holiday/HolidayForm.tsx
@@ -16,8 +16,8 @@ const now = dayjs();
 export const schemaHoliDayForm = Yup.object().shape({
   description: Yup.string().required('Field required').default(''),
   status: Yup.string().required('Field required').default('REQUESTED'),
-  from: Yup.date().required('From date is required').default(now),
-  to: Yup.date().required('To date is required').default(now),
+  from: Yup.mixed<dayjs.Dayjs>().required('From date is required').default(now),
+  to: Yup.mixed<dayjs.Dayjs>().required('To date is required').default(now),
   days: Yup.array().default([8]).nullable(),
 });
 

--- a/workday-application/src/main/react/features/holiday/LeaveDayForm.tsx
+++ b/workday-application/src/main/react/features/holiday/LeaveDayForm.tsx
@@ -14,8 +14,8 @@ const now = dayjs();
 export const schemaLeaveDayForm = Yup.object().shape({
   description: Yup.string().required('Description is required').default(''),
   status: Yup.string().required('Status is required').default('REQUESTED'),
-  from: Yup.date().required('From date is required').default(now),
-  to: Yup.date().required('To date is required').default(now),
+  from: Yup.mixed<dayjs.Dayjs>().required('From date is required').default(now),
+  to: Yup.mixed<dayjs.Dayjs>().required('To date is required').default(now),
   days: Yup.array().default([8]).nullable(),
 });
 

--- a/workday-application/src/main/react/features/holiday/PlusDayForm.tsx
+++ b/workday-application/src/main/react/features/holiday/PlusDayForm.tsx
@@ -15,8 +15,8 @@ const now = dayjs();
 export const schemaPlusDayForm = Yup.object().shape({
   description: Yup.string().required('Description is required').default(''),
   status: Yup.string().required('Status is required').default('REQUESTED'),
-  from: Yup.date().required('From date is required').default(now),
-  to: Yup.date().required('To date is required').default(now),
+  from: Yup.mixed<dayjs.Dayjs>().required('From date is required').default(now),
+  to: Yup.mixed<dayjs.Dayjs>().required('To date is required').default(now),
   hours: Yup.string().required('Hours are required').default(''),
 });
 

--- a/workday-application/src/main/react/features/person/PersonForm.tsx
+++ b/workday-application/src/main/react/features/person/PersonForm.tsx
@@ -138,7 +138,7 @@ export function PersonForm({ item, onSubmit }: PersonFormProps) {
   return (
     <Formik
       initialValues={{
-        ...PERSON_FORM_SCHEMA.cast(),
+        ...PERSON_FORM_SCHEMA.getDefault(),
         active: true,
         ...item,
         userCode: item?.user?.id,

--- a/workday-application/src/main/react/features/sickday/SickDayDialog.tsx
+++ b/workday-application/src/main/react/features/sickday/SickDayDialog.tsx
@@ -6,6 +6,7 @@ import { ConfirmDialog } from '@workday-core/components/ConfirmDialog';
 import { DialogFooter, DialogHeader } from '@workday-core/components/dialog';
 import { DialogBody } from '@workday-core/components/dialog/DialogHeader';
 import UserAuthorityUtil from '@workday-user/user_utils/UserAuthorityUtil';
+import type { Dayjs } from 'dayjs';
 import { useEffect, useState } from 'react';
 import { SickDayClient } from '../../clients/SickDayClient';
 import { ISO_8601_DATE } from '../../clients/util/DateFormats';
@@ -23,9 +24,9 @@ type SickDayDialogProps = {
 type SickDayDialogForm = {
   description: string;
   status: string;
-  from: string;
-  to: string;
-  days: number;
+  from: Dayjs;
+  to: Dayjs;
+  days: number[];
 };
 
 export function SickDayDialog({
@@ -75,7 +76,7 @@ export function SickDayDialog({
           });
         });
       } else {
-        setState(schemaSickDayForm.default());
+        setState(schemaSickDayForm.getDefault());
       }
     }
   }, [code, open]);

--- a/workday-application/src/main/react/features/sickday/SickDayForm.tsx
+++ b/workday-application/src/main/react/features/sickday/SickDayForm.tsx
@@ -15,8 +15,8 @@ const now = dayjs();
 export const schemaSickDayForm = Yup.object().shape({
   description: Yup.string().default(''),
   status: Yup.string().required('Field required').default('REQUESTED'),
-  from: Yup.date().required('From date is required').default(now),
-  to: Yup.date().required('To date is required').default(now),
+  from: Yup.mixed<dayjs.Dayjs>().required('From date is required').default(now),
+  to: Yup.mixed<dayjs.Dayjs>().required('To date is required').default(now),
   days: Yup.array().default([8]).nullable(),
 });
 

--- a/workday-application/src/main/react/features/workday/WorkDayDialog.tsx
+++ b/workday-application/src/main/react/features/workday/WorkDayDialog.tsx
@@ -80,7 +80,7 @@ export function WorkDayDialog({ personFullName, open, code, onComplete }) {
           });
         });
       } else {
-        setState(schema.cast());
+        setState(schema.getDefault());
       }
     } else {
       setState(null);

--- a/workday-application/src/main/react/features/workday/WorkDayForm.tsx
+++ b/workday-application/src/main/react/features/workday/WorkDayForm.tsx
@@ -29,10 +29,10 @@ export const schema = Yup.object().shape({
     .required('Assignment is required')
     .nullable()
     .default(''),
-  from: Yup.date().required('From date is required').default(now),
-  to: Yup.date().required('To date is required').default(now),
+  from: Yup.mixed<dayjs.Dayjs>().required('From date is required').default(now),
+  to: Yup.mixed<dayjs.Dayjs>().required('To date is required').default(now),
   days: Yup.array().default([8]).nullable(),
-  hours: Yup.number().default('0'),
+  hours: Yup.number().default(0),
   sheets: Yup.array().default([]),
 });
 
@@ -192,7 +192,7 @@ export function WorkDayForm({ value, onSubmit }: WorkDayFormProps) {
   return value ? (
     <Formik
       enableReinitialize
-      initialValues={mutatePeriod(value) || schema.default()}
+      initialValues={mutatePeriod(value) || schema.getDefault()}
       onSubmit={handleSubmit}
       validationSchema={schema}
     >


### PR DESCRIPTION
## What

Upgrades `yup` `^0.27.0` → `^1.7.1` and migrates all 17 form-schema files to the yup 1.0 API. Supersedes dependabot #430 (which bumped the dep with no code migration, so it failed CI).

## Migration

No `.when()` usages exist, which avoids 1.0's biggest breaking change. The changes:

| Change | Why |
|---|---|
| 0-arg `schema.cast()` / `schema.default()` → `schema.getDefault()` | In 1.0 `cast`/`default` are setters; reading the defaults object (used to seed Formik `initialValues`) is now `getDefault()`. |
| `Yup.date().default(now)` → `Yup.mixed<dayjs.Dayjs>()` | These fields hold **Dayjs** (via `DatePickerField`); 1.0 types `date()` as JS `Date` and rejects Dayjs. Matches the existing `mixed()` pattern in `AssignmentSchema`. Validation unchanged (required-only). |
| `.default('0')`, `.default('')` on `number()` → `.default(0)` | Latent bug: string default on a number schema, now caught by 1.0's stricter typing. |
| `SickDayDialogForm.from/to`: `string` → `Dayjs` | `SickDayClient` already internalizes responses to Dayjs (`from: dayjs(it.from)`); the `string` type was wrong and only compiled because 0.x `cast()` returned `any`. |
| `AssignmentForm` `initialValues` asserted to `AssignmentRequest` | Form holds Dayjs; conversion to the wire (string-date) contract happens at the submit boundary. Restores the looseness `cast(): any` gave before — zero runtime change. |

## Verification (local)
- `tsc --noEmit`: **0 errors**
- `npm run build` (vite): passes
- `npm test` (jest): **25/25 green**

Mechanical codemods (cast/default → getDefault, date → mixed) were applied with ast-grep; the rest by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)