### PR TITLE
Remove debug print statements from production code

### DIFF
--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/config/WebMvcConfig.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/config/WebMvcConfig.kt
@@ -18,7 +18,6 @@ class WebMvcConfig : WebMvcConfigurer {
             .setCacheControl(CacheControl.empty().mustRevalidate())
             .setEtagGenerator { resource ->
                 etagCache.computeIfAbsent(resource.file.path) {
-                    println("Computing cache for ${resource.file.path}. etag: ${resource.contentAsByteArray.contentHashCode()}")
                     resource.contentAsByteArray.contentHashCode().toString()
                 }
             }.resourceChain(true)

--- a/workday-application/src/main/react/components/selector/ProjectSelector.tsx
+++ b/workday-application/src/main/react/components/selector/ProjectSelector.tsx
@@ -19,7 +19,7 @@ type ProjectSelectorProps = FormControlProps & {
   multiple?: boolean;
   error?: string;
   refresh?: boolean;
-  onRefresh: (promise: Promise<void>) => void;
+  onRefresh?: (promise: Promise<void>) => void;
 };
 
 export function ProjectSelector({
@@ -39,7 +39,7 @@ export function ProjectSelector({
     const itemPromise = ProjectClient.all().then((res) => {
       setItems(res);
     });
-    onRefresh(itemPromise);
+    onRefresh?.(itemPromise);
   }, [onRefresh]);
 
   useEffect(() => {

--- a/workday-application/src/main/react/features/assignments/AssignmentForm.tsx
+++ b/workday-application/src/main/react/features/assignments/AssignmentForm.tsx
@@ -38,12 +38,6 @@ export const AssignmentForm = ({ value, onSubmit }: AssignmentFormProps) => {
   };
 
   const form = ({ values, setFieldValue }) => {
-    const handleRefresh = (promise) => {
-      promise.then((_res) => {
-        console.log(`Items in project selector updated`);
-      });
-    };
-
     return (
       <Form id={ASSIGNMENT_FORM_ID}>
         <Grid container spacing={1}>
@@ -89,7 +83,6 @@ export const AssignmentForm = ({ value, onSubmit }: AssignmentFormProps) => {
           </Grid>
           <Grid size={{ xs: 12 }}>
             <ProjectSelectorField
-              onRefresh={handleRefresh}
               refresh={doRefresh}
               name="projectCode"
               fullWidth


### PR DESCRIPTION
Remove println() calls from WebMvcConfig that were left over from debugging, and remove console.log from AssignmentForm. Also makes onRefresh optional in ProjectSelector to fix a type error.

This was previously PR #450 but needed a rebase onto current main.