### PR TITLE
fix: force-push Playwright report to gh-pages to prevent race

### DIFF
--- a/.github/workflows/gcp.yml
+++ b/.github/workflows/gcp.yml
@@ -162,6 +162,7 @@ jobs:
           publish_dir: ./playwright-report
           destination_dir: ${{ steps.pages-target.outputs.dir }}
           keep_files: true
+          force: true
           commit_message: "Publish Playwright report for ${{ steps.pages-target.outputs.label }}"
           user_name: "github-actions[bot]"
           user_email: "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
Multiple concurrent CI runs push to gh-pages simultaneously. The peaceiris/actions-gh-pages action rejects when the remote has advanced since the last fetch (`! [rejected\]` non-fast-forward).

With `keep_files: true` and unique `destination_dir` per run (main/ or pr-NN/), `force: true` only overwrites that subdirectory without affecting other reports.