### PR TITLE
feat: budget-allocation schema, migrations only [3/4]

### DIFF
--- a/workday-application/src/main/database/db/changelog/db.changelog-030-budget-allocations.yaml
+++ b/workday-application/src/main/database/db/changelog/db.changelog-030-budget-allocations.yaml
@@ -1,0 +1,182 @@
+databaseChangeLog:
+  - changeSet:
+      id: db.changelog-030-budget-allocations-0
+      author: rkorver
+      comment: Sequence for TimeAllocation entity (Hibernate 6 entity sequence)
+      changes:
+        - createSequence:
+            sequenceName: time_allocation_seq
+            startValue: 1
+            incrementBy: 50
+  - changeSet:
+      id: db.changelog-030-budget-allocations-1
+      author: rkorver
+      comment: Sequence for MoneyAllocation entity (Hibernate 6 entity sequence)
+      changes:
+        - createSequence:
+            sequenceName: money_allocation_seq
+            startValue: 1
+            incrementBy: 50
+  - changeSet:
+      id: db.changelog-030-budget-allocations-2
+      author: rkorver
+      comment: Time allocation aggregate; total hours derived from typed daily rows
+      changes:
+        - createTable:
+            tableName: time_allocation
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: time_allocationPK
+                  name: id
+                  type: BIGINT
+              - column:
+                  constraints:
+                    unique: true
+                  name: code
+                  type: VARCHAR(255)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: person_id
+                  type: BIGINT
+              - column:
+                  name: event_code
+                  type: VARCHAR(255)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: date
+                  type: DATE
+              - column:
+                  name: description
+                  type: VARCHAR(255)
+  - changeSet:
+      id: db.changelog-030-budget-allocations-3
+      author: rkorver
+      comment: Typed daily hours per time allocation; several rows per date allowed (no unique on allocation+date)
+      changes:
+        - createTable:
+            tableName: time_allocation_days
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                  name: time_allocation_id
+                  type: BIGINT
+              - column:
+                  name: date
+                  type: DATE
+              - column:
+                  name: hours
+                  type: DOUBLE
+              - column:
+                  name: type
+                  type: VARCHAR(255)
+  - changeSet:
+      id: db.changelog-030-budget-allocations-4
+      author: rkorver
+      comment: Money allocation aggregate (study/training money draws)
+      changes:
+        - createTable:
+            tableName: money_allocation
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: money_allocationPK
+                  name: id
+                  type: BIGINT
+              - column:
+                  constraints:
+                    unique: true
+                  name: code
+                  type: VARCHAR(255)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: person_id
+                  type: BIGINT
+              - column:
+                  name: event_code
+                  type: VARCHAR(255)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: date
+                  type: DATE
+              - column:
+                  constraints:
+                    nullable: false
+                  name: amount
+                  type: DECIMAL(19, 2)
+              - column:
+                  name: description
+                  type: VARCHAR(255)
+  - changeSet:
+      id: db.changelog-030-budget-allocations-5
+      author: rkorver
+      comment: Receipt files attached to a money allocation
+      changes:
+        - createTable:
+            tableName: money_allocation_files
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                  name: money_allocation_id
+                  type: BIGINT
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+              - column:
+                  name: file
+                  type: UUID
+  - changeSet:
+      id: db.changelog-030-budget-allocations-6
+      author: rkorver
+      comment: Foreign keys; allocations cascade-delete with their person and parent aggregate
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: person_id
+            baseTableName: time_allocation
+            constraintName: FK_time_allocation_person
+            deferrable: false
+            initiallyDeferred: false
+            onDelete: CASCADE
+            referencedColumnNames: id
+            referencedTableName: person
+            validate: true
+        - addForeignKeyConstraint:
+            baseColumnNames: time_allocation_id
+            baseTableName: time_allocation_days
+            constraintName: FK_time_allocation_days_time_allocation
+            deferrable: false
+            initiallyDeferred: false
+            onDelete: CASCADE
+            referencedColumnNames: id
+            referencedTableName: time_allocation
+            validate: true
+        - addForeignKeyConstraint:
+            baseColumnNames: person_id
+            baseTableName: money_allocation
+            constraintName: FK_money_allocation_person
+            deferrable: false
+            initiallyDeferred: false
+            onDelete: CASCADE
+            referencedColumnNames: id
+            referencedTableName: person
+            validate: true
+        - addForeignKeyConstraint:
+            baseColumnNames: money_allocation_id
+            baseTableName: money_allocation_files
+            constraintName: FK_money_allocation_files_money_allocation
+            deferrable: false
+            initiallyDeferred: false
+            onDelete: CASCADE
+            referencedColumnNames: id
+            referencedTableName: money_allocation
+            validate: true

--- a/workday-application/src/main/database/db/changelog/db.changelog-031-event-default-time-allocation-type.yaml
+++ b/workday-application/src/main/database/db/changelog/db.changelog-031-event-default-time-allocation-type.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: db.changelog-031-event-default-time-allocation-type
+      author: rkorver
+      changes:
+        - addColumn:
+            tableName: event
+            columns:
+              - column:
+                  name: default_time_allocation_type
+                  type: VARCHAR(255)

--- a/workday-application/src/main/database/db/changelog/db.changelog-master.yaml
+++ b/workday-application/src/main/database/db/changelog/db.changelog-master.yaml
@@ -85,4 +85,10 @@ databaseChangeLog:
   - include:
       file: db.changelog-029-rename-hack-hours-to-hack-time-budget.yaml
       relativeToChangelogFile: true
+  - include:
+      file: db.changelog-030-budget-allocations.yaml
+      relativeToChangelogFile: true
+  - include:
+      file: db.changelog-031-event-default-time-allocation-type.yaml
+      relativeToChangelogFile: true
 


### PR DESCRIPTION
> **Per-person budget tracking · Phase 3 of 4.** The EventDay refactor (#528) is the per-person event-hours foundation; the hack/study budget-allocation feature is built on top of it. Merge in order; each PR rebases onto `main` after the previous lands.
>
> 1. **Phase 1 · EventDay expand** (#530) — add `event_day`, backfill, keep `event_persons` (rollback-safe). Changelogs `030`/`031`.
> 2. **Phase 2 · EventDay contract** (#533) — drop `event_persons`, after Phase 1 is verified in prod. Changelogs `032`/`033`.
> 3. **Phase 3 · Budget-allocation schema** (#524) ← this PR — the allocation tables. ⚠️ currently `030`/`031` (collides with Phase 1); renumber to `034`/`035` before merge.
> 4. **Phase 4 · Budget backend + frontend** (#526) — consuming app code; no migrations.
>
> All four touch `db.changelog-master.yaml`, so expect a conflict to resolve on each rebase.

> [!WARNING]
> **Liquibase numbering collides with Phase 1 (#530) and must be renumbered before merge.** This branch's `030-budget-allocations` and `031-event-default-time-allocation-type` reuse the same `030`/`031` that #530 takes for `event_day`. Under the agreed sequence EventDay lands first (`030`–`033`), so when rebasing onto `main` rename these to **`034`/`035`** (the changelog files, the changeset `id`s, and the `db.changelog-master.yaml` include). The numbers below describe the current branch, pre-renumber.

The Liquibase changelogs only, no consuming Kotlin/React code. Splitting the schema into its own release lets it deploy and roll back independently of the app code (per Willem's preference) and isolates any migration failure from a code rollback.

## Schema

![Budget allocations schema (ERD)](https://github.com/user-attachments/assets/fbc2b830-c455-405b-bfa0-5258ef1738f4)

Two independent aggregates, each keyed by a unique business `code` (not the numeric `id`), each owning a child collection and cascading from `person`:

- **`time_allocation`** + **`time_allocation_days`** — typed per-day hour rows (`HACK | TRAINING`). No unique on `(allocation, date)`, so a single day can carry several rows and mix types. Total hours are derived from these rows.
- **`money_allocation`** + **`money_allocation_files`** — study/training money draws (`amount DECIMAL(19,2)`) with attached receipt files.

`event_code` on both roots is a soft reference (string, no FK). The companion changelog adds a nullable `event.default_time_allocation_type` column — a UI pre-fill hint, nothing consumes it yet.

## Changesets

- **`030-budget-allocations`** (→ `034`) — 4 tables + 2 sequences (`time_allocation_seq` / `money_allocation_seq`, Hibernate 6 entity ids, `incrementBy 50`) + 4 FKs. FKs only reference `person` and the new tables; all `ON DELETE CASCADE`.
- **`031-event-default-time-allocation-type`** (→ `035`) — nullable `default_time_allocation_type` column on `event`.

> [!IMPORTANT]
> **Schema contract change — additive and safe against the running app.** New tables/columns/sequences only; nothing existing is altered or dropped. Sequenced to land after the EventDay changelogs (`030`–`033`); see the renumber note above.

Validated with a full `liquibase:update` against a fresh H2: 114 changesets, 0 previously-run, 0 conflicts, no duplicate-column errors (validated at the current `030`/`031` numbering; re-validate after the renumber).
