### PR TITLE
test: fix expense e2e assertion broken by #522 card relabel

### DIFF
--- a/tests/workday.spec.ts
+++ b/tests/workday.spec.ts
@@ -79,7 +79,7 @@ test.describe('Workday scenarios', () => {
       page,
       'Requested',
       'Some reason',
-      'Date: 10-06-2028',
+      '10-06-2028',
       '€ 16,50',
     );
   });


### PR DESCRIPTION
## Why
main is red. The `Submitting an expense` Playwright test fails deterministically (through all retries), which blocks the production approval gate — and any branch off main, including the schema PR #524.

## Root cause
#522 (design-token theme) redesigned the expense card:

```
- Date: {dayjs(item.date).format('DD-MM-YYYY')} | Total: {amount}
+ <span>{dayjs(item.date).format('DD-MM-YYYY')}</span> · {amount}
```

The `Date:` / `| Total:` labels were dropped, so the card now renders `10-06-2028 · € 16,50`. The e2e still asserted the card contained `Date: 10-06-2028`, which no longer exists. Not an app bug — a stale assertion.

## Change
Assert the bare `10-06-2028` the card now renders. `€ 16,50` is unchanged and still matches. Single-line test change, no app code touched.

Unblocks: green main → production gate → #524.