### PR TITLE
fix: black text on yellow highlight in dark mode

### DIFF
--- a/workday-application/src/main/react/theme/theme-light.ts
+++ b/workday-application/src/main/react/theme/theme-light.ts
@@ -6,6 +6,7 @@ export const themeLight = createAppTheme('light');
 export const HighlightSpan = styled('span')(({ theme }) => ({
   position: 'relative',
   fontFamily: theme.typography.fontFamily,
+  color: theme.palette.primary.contrastText,
   '&::before': {
     content: '""',
     backgroundColor: theme.palette.primary.main,


### PR DESCRIPTION
## What
The Flock-yellow "marker" highlight behind key numbers/names rendered near-white text in dark mode (low contrast on yellow). `HighlightSpan` now sets `color: theme.palette.primary.contrastText` (brand ink, identical in both palettes), so highlighted text is dark-on-yellow in both light and dark mode. The yellow `::before` marker is not theme-gated, so dark ink is correct in both.

Affects: home greeting (`Hi, <name>!`), Leave-days and Hack-days hour counts.

## Scope
- One line, `theme/theme-light.ts`.
- The matching **login-header** fix already shipped in #529, so it is out of scope here. This branch is rebased on top of #529.

## Verification
- biome ✅, jest 32/32 ✅, tsc clean for the changed file.
- Verified in dark and light mode; light mode unchanged (the inherited colour there was already ink).

> Note: a review flagged that at the marker's ragged edges, dark glyph pixels that spill off the yellow band sit dark-on-dark. The text body is on the marker and fully legible; this only touches a few trailing/top edge pixels and is a clear net win over the prior white-on-yellow. Can tighten marker coverage in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)