### PR TITLE
refactor: drop event_persons, EventDay contract [2/2]

### DIFF
--- a/workday-application/src/main/database/db/changelog/db.changelog-032-drop-event-persons.yaml
+++ b/workday-application/src/main/database/db/changelog/db.changelog-032-drop-event-persons.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: db.changelog-032-drop-event-persons
+      author: rkorver
+      comment: >-
+        Contract step: event participants now derive from EventDay, so drop the obsolete
+        event_persons table. Runs after db.changelog-033 has re-synced any rows the prior
+        release may have written during an expand-phase rollback window.
+      changes:
+        - dropTable:
+            tableName: event_persons

--- a/workday-application/src/main/database/db/changelog/db.changelog-033-event-day-backfill-catchup.yaml
+++ b/workday-application/src/main/database/db/changelog/db.changelog-033-event-day-backfill-catchup.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: db.changelog-033-event-day-backfill-catchup
+      author: rkorver
+      comment: >-
+        Contract safety net: re-runs the idempotent EventDay backfill so any event_persons
+        rows the previous release wrote during an expand-phase rollback window get an
+        EventDay before db.changelog-032 drops the table. No-op if none diverged.
+      changes:
+        - customChange:
+            class: community.flock.eco.workday.application.migrations.BackfillEventDays

--- a/workday-application/src/main/database/db/changelog/db.changelog-master.yaml
+++ b/workday-application/src/main/database/db/changelog/db.changelog-master.yaml
@@ -85,12 +85,18 @@ databaseChangeLog:
   - include:
       file: db.changelog-029-rename-hack-hours-to-hack-time-budget.yaml
       relativeToChangelogFile: true
-  # event_persons is intentionally kept: 030+031 expand only, leaving the table so the
-  # prior release stays rollback-safe. The drop ships in a separate follow-up PR.
+  # Expand (030+031) shipped earlier and kept event_persons for rollback safety. Contract:
+  # 033 re-syncs any rows written during the rollback window, then 032 drops the table.
   - include:
       file: db.changelog-030-event-day.yaml
       relativeToChangelogFile: true
   - include:
       file: db.changelog-031-event-day-backfill.yaml
+      relativeToChangelogFile: true
+  - include:
+      file: db.changelog-033-event-day-backfill-catchup.yaml
+      relativeToChangelogFile: true
+  - include:
+      file: db.changelog-032-drop-event-persons.yaml
       relativeToChangelogFile: true
 


### PR DESCRIPTION
Contract half of the EventDay migration (#528), split out from #530 so the expand phase can be verified in prod before anything is dropped.

#530 (expand) ships `030` (create `event_day`) + `031` (backfill) and **keeps** the `event_persons` table, so a rollback to the previous release stays safe. This PR finishes the job:

- `033`: idempotent catch-up backfill — picks up any `event_persons` rows the old release may have written during an expand-phase rollback window (no-op if none diverged).
- `032`: drops the now-obsolete `event_persons` table.

> [!WARNING]
> Merge and deploy **only after #530 is live and verified in prod**. This branch is stacked on `refactor/event-day-per-person-528`; rebase onto `main` once #530 merges.

```mermaid
flowchart TD
    A["Release N-1<br/>reads event_persons"] -->|"#530 expand"| B["030 create event_day<br/>031 backfill<br/>event_persons KEPT"]
    B -->|"verify in prod"| C{healthy?}
    C -->|"no → redeploy N-1"| A
    C -->|"yes → this PR"| D["033 catch-up backfill<br/>032 drop event_persons"]
    style B fill:#fde68a,stroke:#333
    style D fill:#bbf7d0,stroke:#333
```

Verified locally by simulating the rollout: seeded old-schema data on `main` (98 `event_persons`), ran the expand migration (98 `event_day`, table kept), booted old code against the expanded DB (clean rollback), then ran this contract phase (`event_persons` dropped). Backend tests green.
