### PR TITLE
feat: budget-on-EventDay schema migration (supersedes #524)

### DIFF
--- a/workday-application/src/main/database/db/changelog/db.changelog-034-budget-on-event-day.yaml
+++ b/workday-application/src/main/database/db/changelog/db.changelog-034-budget-on-event-day.yaml
@@ -1,0 +1,63 @@
+databaseChangeLog:
+  - changeSet:
+      id: db.changelog-034-budget-on-event-day-0
+      author: rkorver
+      comment: >-
+        Per-person event money draw. EventDay already carries per-person event hours; cost
+        adds the matching money dimension, so used hack/study time and money both derive
+        from EventDay instead of separate allocation tables.
+      changes:
+        - addColumn:
+            tableName: event_day
+            columns:
+              - column:
+                  name: cost
+                  type: DECIMAL(19, 2)
+  - changeSet:
+      id: db.changelog-034-budget-on-event-day-1
+      author: rkorver
+      comment: Receipt files attached to an EventDay (reuses the Document embeddable, like cost_expense_files)
+      changes:
+        - createTable:
+            tableName: event_day_files
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                  name: event_day_id
+                  type: BIGINT
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+              - column:
+                  name: file
+                  type: UUID
+  - changeSet:
+      id: db.changelog-034-budget-on-event-day-2
+      author: rkorver
+      comment: Receipt files cascade-delete with their EventDay
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: event_day_id
+            baseTableName: event_day_files
+            constraintName: FK_event_day_files_event_day
+            deferrable: false
+            initiallyDeferred: false
+            onDelete: CASCADE
+            referencedColumnNames: id
+            referencedTableName: event_day
+            validate: true
+  - changeSet:
+      id: db.changelog-034-budget-on-event-day-3
+      author: rkorver
+      comment: >-
+        Per-event HACK|TRAINING marker. EventDay hours/cost derive a person's used hack/study
+        budget, but the category is not reducible to event.type (a self-booked study event is
+        TRAINING, not a CONFERENCE), so it is set explicitly here.
+      changes:
+        - addColumn:
+            tableName: event
+            columns:
+              - column:
+                  name: default_time_allocation_type
+                  type: VARCHAR(255)

--- a/workday-application/src/main/database/db/changelog/db.changelog-master.yaml
+++ b/workday-application/src/main/database/db/changelog/db.changelog-master.yaml
@@ -99,4 +99,8 @@ databaseChangeLog:
   - include:
       file: db.changelog-032-drop-event-persons.yaml
       relativeToChangelogFile: true
+  # Budget (time + money) lives on EventDay; no separate allocation tables.
+  - include:
+      file: db.changelog-034-budget-on-event-day.yaml
+      relativeToChangelogFile: true
 


### PR DESCRIPTION
Schema for the hack/study **budget** feature, reshaped onto `EventDay`. Schema-only (Liquibase), so it can ship/roll back independently of the consuming code (per Willem).

Supersedes #524 (separate `time_allocation` + `money_allocation` tables) and the consuming #526. Both are closed in favour of this unified model.

## Why the reshape

#530 now models per-person event **hours** as `EventDay : Day`. Per-person event **money** is the same shape (one amount, per person, per event), so it rides the same row instead of a parallel aggregate. The old `TimeAllocation` simply duplicated `EventDay`; `MoneyAllocation` becomes a `cost` column. Time **and** money then derive from one place, classified by an event-level marker.

```mermaid
flowchart LR
  E[Event<br/>+ default_time_allocation_type<br/>HACK|TRAINING] -->|@OneToMany| ED["EventDay : Day<br/>hours + cost + receipts"]
  ED -->|@ManyToOne| P[Person]
  style ED fill:#fde68a,stroke:#333
```

- **used hack/training hours** = Σ `EventDay.hours` by marker
- **used training money** = Σ `EventDay.cost` by marker
- **private study** = a self-booked event marked `TRAINING`, carrying hours + cost + receipt on one EventDay

## Changeset `034-budget-on-event-day`

- `event_day.cost` `DECIMAL(19,2)` — per-person money draw
- `event_day_files` (+ FK, `ON DELETE CASCADE`) — receipts via the `Document` embeddable, same pattern as `cost_expense_files`
- `event.default_time_allocation_type` `VARCHAR` — the HACK|TRAINING marker (category isn't reducible to `EventType`)

No new tables for allocations, **no new sequences** (reuses `day_seq`/`event_day`). Numbered `034`, after the event-day chain `030–033`.

## Validation

Full `liquibase:update` against a fresh PostgreSQL-mode H2 → **113/113 changesets clean**; `event_day.cost`, `event_day_files`, `event.default_time_allocation_type` present, no `time_allocation`/`money_allocation`.

> [!NOTE]
> **Stacked** on `refactor/drop-event-persons-528` (#533 contract → #530 expand). Rebase onto `main` and retarget once the event-day stack lands. The consuming code (EventDay cost/receipts, EventService split, EventDay-derived summary, budget admin UI) is a follow-up PR reimplemented around this model.