### PR TITLE
refactor: drop redundant event_days, derive breakdown from EventDay

### DIFF
--- a/workday-application/src/main/database/db/changelog/db.changelog-033-event-day-breakdown-backfill.yaml
+++ b/workday-application/src/main/database/db/changelog/db.changelog-033-event-day-breakdown-backfill.yaml
@@ -1,0 +1,8 @@
+databaseChangeLog:
+  - changeSet:
+      id: db.changelog-033-event-day-breakdown-backfill
+      author: rkorver
+      comment: Fill day_days from event_days for any EventDay still missing its breakdown, so nothing is lost when event_days is dropped (034).
+      changes:
+        - customChange:
+            class: community.flock.eco.workday.application.migrations.BackfillEventDayBreakdown

--- a/workday-application/src/main/database/db/changelog/db.changelog-034-drop-event-days.yaml
+++ b/workday-application/src/main/database/db/changelog/db.changelog-034-drop-event-days.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: db.changelog-034-drop-event-days
+      author: rkorver
+      comment: >-
+        The event-level day breakdown now derives from the per-person EventDays
+        (stored in day_days), so the Event no longer owns an event_days collection.
+        Backfills 031 + 033 moved these values into day_days; drop the table.
+      changes:
+        - dropTable:
+            tableName: event_days

--- a/workday-application/src/main/database/db/changelog/db.changelog-master.yaml
+++ b/workday-application/src/main/database/db/changelog/db.changelog-master.yaml
@@ -95,3 +95,11 @@ databaseChangeLog:
       file: db.changelog-032-drop-event-persons.yaml
       relativeToChangelogFile: true
 
+  - include:
+      file: db.changelog-033-event-day-breakdown-backfill.yaml
+      relativeToChangelogFile: true
+
+  - include:
+      file: db.changelog-034-drop-event-days.yaml
+      relativeToChangelogFile: true
+

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/EventController.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/EventController.kt
@@ -180,7 +180,6 @@ class EventController(
         Event(
             description = "N/A - $description",
             costs = 0.00,
-            days = null,
             id = id,
             code = code,
             from = from,

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/migrations/BackfillEventDayBreakdown.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/migrations/BackfillEventDayBreakdown.kt
@@ -1,0 +1,68 @@
+package community.flock.eco.workday.application.migrations
+
+import liquibase.change.custom.CustomTaskChange
+import liquibase.database.Database
+import liquibase.database.jvm.JdbcConnection
+import liquibase.exception.ValidationErrors
+import liquibase.resource.ResourceAccessor
+import java.sql.Connection
+
+// Catch-up before event_days is dropped: 031 backfilled day_days only for EventDays it
+// created from event_persons, so fill any EventDay still missing a breakdown from its
+// event's event_days. Only touches EventDays with empty day_days, so re-running is safe.
+class BackfillEventDayBreakdown : CustomTaskChange {
+    private var filled = 0
+
+    override fun execute(database: Database) {
+        val connection = (database.connection as JdbcConnection).underlyingConnection
+        val daysByEvent = readDaysByEvent(connection)
+
+        val insertDayValue = connection.prepareStatement(INSERT_DAY_VALUE)
+        val missing = connection.prepareStatement(SELECT_EVENT_DAYS_WITHOUT_BREAKDOWN)
+        try {
+            missing.executeQuery().use { rows ->
+                while (rows.next()) {
+                    val dayId = rows.getLong("day_id")
+                    val eventId = rows.getLong("event_id")
+                    daysByEvent[eventId].orEmpty().forEach { dayValue ->
+                        insertDayValue.run {
+                            setLong(1, dayId)
+                            setDouble(2, dayValue)
+                            executeUpdate()
+                        }
+                        filled++
+                    }
+                }
+            }
+        } finally {
+            listOf(missing, insertDayValue).forEach { it.close() }
+        }
+    }
+
+    private fun readDaysByEvent(connection: Connection): Map<Long, List<Double>> =
+        connection.prepareStatement("SELECT event_id, days FROM event_days").use { stmt ->
+            stmt.executeQuery().use { rows ->
+                buildMap<Long, MutableList<Double>> {
+                    while (rows.next()) {
+                        getOrPut(rows.getLong("event_id")) { mutableListOf() }.add(rows.getDouble("days"))
+                    }
+                }
+            }
+        }
+
+    override fun getConfirmationMessage() = "Backfilled $filled day_days rows from event_days for EventDays missing a breakdown"
+
+    override fun setUp() = Unit
+
+    override fun setFileOpener(resourceAccessor: ResourceAccessor?) = Unit
+
+    override fun validate(database: Database?): ValidationErrors = ValidationErrors()
+
+    private companion object {
+        const val INSERT_DAY_VALUE = "INSERT INTO day_days (day_id, days) VALUES (?, ?)"
+        const val SELECT_EVENT_DAYS_WITHOUT_BREAKDOWN =
+            """SELECT ed.id AS day_id, ed.event_id AS event_id
+               FROM event_day ed
+               WHERE NOT EXISTS (SELECT 1 FROM day_days dd WHERE dd.day_id = ed.id)"""
+    }
+}

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/model/Event.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/model/Event.kt
@@ -3,7 +3,6 @@ package community.flock.eco.workday.application.model
 import community.flock.eco.workday.application.interfaces.Daily
 import community.flock.eco.workday.core.events.EventEntityListeners
 import community.flock.eco.workday.core.model.AbstractCodeEntity
-import jakarta.persistence.ElementCollection
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.EnumType
@@ -26,12 +25,13 @@ class Event(
     val costs: Double,
     @Enumerated(EnumType.STRING)
     val type: EventType,
-    @ElementCollection(fetch = FetchType.EAGER)
-    override val days: MutableList<Double>? = null,
     @OneToMany(mappedBy = "event", fetch = FetchType.EAGER)
     @BatchSize(size = 50)
     val eventDays: MutableList<EventDay> = mutableListOf(),
 ) : AbstractCodeEntity(id, code),
     Daily {
     val persons: List<Person> get() = eventDays.map { it.person }.distinct()
+
+    // EventDays share one breakdown until per-person hours editing exists, so the first represents the event.
+    override val days: MutableList<Double>? get() = eventDays.firstOrNull()?.days
 }

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/services/EventService.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/services/EventService.kt
@@ -98,32 +98,36 @@ class EventService(
                     from = from,
                     to = to,
                     hours = hours,
-                    days = days.toMutableList(),
                     costs = costs,
                     type = type,
                 ),
             )
         val persons = personService.findByPersonCodeIdIn(personIds).toList()
-        event.rebuildEventDaysFromTemplate(persons)
+        event.rebuildEventDaysFromTemplate(persons, days)
         return event.refreshed()
     }
 
     // Rebuilt (not membership-diffed) so an edited period/hours/days reaches every
     // participant — each EventDay holds its own copy of those values.
-    private fun Event.rebuildEventDaysFromTemplate(persons: List<Person>) {
+    private fun Event.rebuildEventDaysFromTemplate(
+        persons: List<Person>,
+        days: List<Double>,
+    ) {
         eventDayRepository.deleteAll(eventDayRepository.findAllByEventCode(code))
-        persons.forEach { eventDayRepository.save(eventDayFor(it)) }
+        persons.forEach { eventDayRepository.save(eventDayFor(it, days)) }
     }
 
-    private fun Event.eventDayFor(person: Person) =
-        EventDay(
-            from = from,
-            to = to,
-            hours = hours,
-            days = days?.toMutableList(),
-            person = person,
-            event = this,
-        )
+    private fun Event.eventDayFor(
+        person: Person,
+        days: List<Double>? = this.days,
+    ) = EventDay(
+        from = from,
+        to = to,
+        hours = hours,
+        days = days?.toMutableList(),
+        person = person,
+        event = this,
+    )
 
     private fun Event.refreshed(): Event =
         also {

--- a/workday-application/src/test/kotlin/community/flock/eco/workday/repository/EventRepositoryTest.kt
+++ b/workday-application/src/test/kotlin/community/flock/eco/workday/repository/EventRepositoryTest.kt
@@ -35,7 +35,6 @@ class EventRepositoryTest : WorkdayIntegrationTest() {
                     from = LocalDate.now(),
                     to = LocalDate.now().plusDays(5),
                     hours = 40.0,
-                    days = mutableListOf(8.0, 8.0, 8.0, 8.0, 8.0),
                     costs = 538.38,
                     type = EventType.GENERAL_EVENT,
                 ),

--- a/workday-application/src/test/kotlin/community/flock/eco/workday/services/AggregationServiceTest.kt
+++ b/workday-application/src/test/kotlin/community/flock/eco/workday/services/AggregationServiceTest.kt
@@ -798,7 +798,6 @@ class AggregationServiceTest(
                     from = day,
                     to = day,
                     hours = 8.0,
-                    days = mutableListOf(8.0),
                     costs = 0.0,
                     type = EventType.FLOCK_HACK_DAY,
                 ),


### PR DESCRIPTION
Follow-up to the EventDay migration (#528 → #530 expand, #533 contract). Removes the now-redundant `event_days` collection table.

## Why
`event_days` backed `Event.days`. After the per-person EventDay refactor it's only a **template**: `EventService` copies it into one `EventDay` per person (stored in `day_days`), and hour aggregation reads exclusively from the EventDays. Backfill `031` already copied `event_days` → `day_days`. So every event's breakdown was stored N+1 times and the `event_days` copy fed nothing.

`Event` can't share `day_days` (it's not a `Day`), so the fix is to make `Event.days` derive from its EventDays and drop the table.

## Changes
- **`Event.kt`** — `days` is now a derived `get() = eventDays.firstOrNull()?.days` (no `@ElementCollection`). API/`Daily` contract unchanged.
- **`EventService.kt`** — create/update sources the breakdown from the form into each `EventDay`; subscribe still copies the event's (derived) breakdown.
- **`EventController.redact()`** — dropped the now-gone `days` arg.
- **`db.changelog-033-event-day-breakdown-backfill.yaml`** (`BackfillEventDayBreakdown`) — guarded catch-up: fills `day_days` from `event_days` for any `EventDay` still missing a breakdown (`031` only covered `event_persons` pairs). Idempotent — only touches EventDays with empty `day_days`, never duplicates.
- **`db.changelog-034-drop-event-days.yaml`** — `dropTable event_days` (same shape as the proven `032`).

## Migration safety
The drop is irreversible, so `033` migrates first, `034` drops. The FK lives on `event_days` itself and nothing references it, so the drop is structurally identical to `032` (already in prod).

⚠️ **Caveat:** an event with **zero** participants has no `EventDay`, so its per-day breakdown has no home in the new model and is dropped (its scalar `hours` survives on `event`). Confirm prod has no person-less events with a meaningful `event_days` breakdown before merge — consistent with the existing "empty-persons events count for nobody" decision.

## Verified
- `EventControllerTest` 6/6, `EventRepositoryTest` 1/1, `AggregationServiceTest` 17/17 (incl. per-person divergent-hours hackday case).
- Fresh develop boot ran the full chain `030→031→032→033(backfill, 0 rows on consistent db)→034(drop)`; app started clean against the migrated schema.
- Backfill data path proven on H2/PostgreSQL: an EventDay missing its breakdown gets filled from `event_days`; one that already has it is left untouched (not duplicated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)