### PR TITLE
refactor: one Event type dropdown — derive budget marker from EventType

### DIFF
--- a/workday-application/src/develop/kotlin/community/flock/eco/workday/application/mocks/LoadEventData.kt
+++ b/workday-application/src/develop/kotlin/community/flock/eco/workday/application/mocks/LoadEventData.kt
@@ -1,7 +1,6 @@
 package community.flock.eco.workday.application.mocks
 
 import community.flock.eco.workday.application.forms.EventForm
-import community.flock.eco.workday.application.model.AllocationType
 import community.flock.eco.workday.application.model.Event
 import community.flock.eco.workday.application.model.EventType
 import community.flock.eco.workday.application.services.EventService
@@ -43,7 +42,6 @@ class LoadEventData(
                 personIds = loadPersonData.data.take(3).map { it.uuid },
                 costs = 2400.0,
                 type = EventType.CONFERENCE,
-                defaultTimeAllocationType = AllocationType.TRAINING,
             ),
             EventForm(
                 description = "Personal study budget",
@@ -53,8 +51,7 @@ class LoadEventData(
                 hours = 8.0,
                 personIds = listOf(loadPersonData.findPersonByUserEmail("bert@sesam.straat").uuid),
                 costs = 450.0,
-                type = EventType.GENERAL_EVENT,
-                defaultTimeAllocationType = AllocationType.TRAINING,
+                type = EventType.CONFERENCE,
             ),
         )
 

--- a/workday-application/src/main/database/db/changelog/db.changelog-034-budget-on-event-day.yaml
+++ b/workday-application/src/main/database/db/changelog/db.changelog-034-budget-on-event-day.yaml
@@ -13,17 +13,3 @@ databaseChangeLog:
               - column:
                   name: cost
                   type: DECIMAL(19, 2)
-  - changeSet:
-      id: db.changelog-034-budget-on-event-day-1
-      author: rkorver
-      comment: >-
-        Per-event HACK|TRAINING marker. EventDay hours/cost derive a person's used hack/study
-        budget, but the category is not reducible to event.type (a self-booked study event is
-        TRAINING, not a CONFERENCE), so it is set explicitly here.
-      changes:
-        - addColumn:
-            tableName: event
-            columns:
-              - column:
-                  name: default_time_allocation_type
-                  type: VARCHAR(255)

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/EventController.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/EventController.kt
@@ -14,7 +14,6 @@ import community.flock.eco.workday.api.endpoint.UnsubscribeFromEvent
 import community.flock.eco.workday.application.authorities.EventAuthority
 import community.flock.eco.workday.application.forms.EventForm
 import community.flock.eco.workday.application.forms.EventRatingForm
-import community.flock.eco.workday.application.model.AllocationType
 import community.flock.eco.workday.application.model.Event
 import community.flock.eco.workday.application.model.EventRating
 import community.flock.eco.workday.application.model.EventType
@@ -34,7 +33,6 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
 import java.time.LocalDate
 import java.util.UUID
-import community.flock.eco.workday.api.model.AllocationType as AllocationTypeApi
 import community.flock.eco.workday.api.model.Event as EventApi
 import community.flock.eco.workday.api.model.EventForm as EventFormApi
 import community.flock.eco.workday.api.model.EventFormType as EventFormTypeApi
@@ -202,7 +200,6 @@ class EventController(
             costs = costs ?: 0.0,
             personIds = personIds?.map(UUID::fromString) ?: emptyList(),
             type = type?.toDomain() ?: EventType.GENERAL_EVENT,
-            defaultTimeAllocationType = defaultTimeAllocationType?.toDomain(),
         )
 
     private fun Event.externalize(): EventApi =
@@ -215,7 +212,6 @@ class EventController(
             hours = hours,
             costs = costs,
             type = type.toApi(),
-            defaultTimeAllocationType = allocationType?.toApi(),
             days = days,
             persons = persons.map { it.externalize() },
         )
@@ -289,18 +285,6 @@ class EventController(
             EventFormTypeApi.FLOCK_COMMUNITY_DAY -> EventType.FLOCK_COMMUNITY_DAY
             EventFormTypeApi.CONFERENCE -> EventType.CONFERENCE
             EventFormTypeApi.GENERAL_EVENT -> EventType.GENERAL_EVENT
-        }
-
-    private fun AllocationType.toApi(): AllocationTypeApi =
-        when (this) {
-            AllocationType.HACK -> AllocationTypeApi.HACK
-            AllocationType.TRAINING -> AllocationTypeApi.TRAINING
-        }
-
-    private fun AllocationTypeApi.toDomain(): AllocationType =
-        when (this) {
-            AllocationTypeApi.HACK -> AllocationType.HACK
-            AllocationTypeApi.TRAINING -> AllocationType.TRAINING
         }
 
     private fun GetEventAll.Queries.toPageable(): Pageable {

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/forms/EventForm.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/forms/EventForm.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer
 import community.flock.eco.workday.application.interfaces.Daily
-import community.flock.eco.workday.application.model.AllocationType
 import community.flock.eco.workday.application.model.EventType
 import java.time.LocalDate
 import java.util.UUID
@@ -23,5 +22,4 @@ data class EventForm(
     val costs: Double,
     val personIds: List<UUID>,
     val type: EventType,
-    val defaultTimeAllocationType: AllocationType? = null,
 ) : Daily

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/model/Event.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/model/Event.kt
@@ -3,7 +3,6 @@ package community.flock.eco.workday.application.model
 import community.flock.eco.workday.application.interfaces.Daily
 import community.flock.eco.workday.core.events.EventEntityListeners
 import community.flock.eco.workday.core.model.AbstractCodeEntity
-import jakarta.persistence.Column
 import jakarta.persistence.ElementCollection
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
@@ -27,9 +26,6 @@ class Event(
     val costs: Double,
     @Enumerated(EnumType.STRING)
     val type: EventType,
-    @Enumerated(EnumType.STRING)
-    @Column(name = "default_time_allocation_type")
-    val defaultTimeAllocationType: AllocationType? = null,
     @ElementCollection(fetch = FetchType.EAGER)
     override val days: MutableList<Double>? = null,
     @OneToMany(mappedBy = "event", fetch = FetchType.EAGER)
@@ -40,11 +36,12 @@ class Event(
     val persons: List<Person> get() = eventDays.map { it.person }.distinct()
 
     val allocationType: AllocationType?
-        get() = defaultTimeAllocationType ?: type.defaultAllocationType()
+        get() = type.defaultAllocationType()
 }
 
 private fun EventType.defaultAllocationType(): AllocationType? =
     when (this) {
         EventType.FLOCK_HACK_DAY -> AllocationType.HACK
-        else -> null
+        EventType.CONFERENCE -> AllocationType.TRAINING
+        EventType.FLOCK_COMMUNITY_DAY, EventType.GENERAL_EVENT -> null
     }

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/services/EventService.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/services/EventService.kt
@@ -106,7 +106,6 @@ class EventService(
                     days = days.toMutableList(),
                     costs = costs,
                     type = type,
-                    defaultTimeAllocationType = defaultTimeAllocationType,
                 ),
             )
         val persons = personService.findByPersonCodeIdIn(personIds).toList()

--- a/workday-application/src/main/react/clients/EventClient.ts
+++ b/workday-application/src/main/react/clients/EventClient.ts
@@ -1,7 +1,7 @@
 import { checkResponse, validateResponse } from '@workday-core';
 import dayjs, { type Dayjs } from 'dayjs';
 import InternalizingClient from '../utils/InternalizingClient';
-import type { AllocationType, EventForm } from '../wirespec/model';
+import type { EventForm } from '../wirespec/model';
 import type { Person, PersonLight } from './PersonClient';
 
 const path = '/api/events';
@@ -29,7 +29,6 @@ export type FullFlockEvent = {
   persons: Person[];
   costs: number;
   type: EventType;
-  defaultTimeAllocationType?: AllocationType | null;
 };
 
 type FlockEventRawProjection = {
@@ -53,7 +52,6 @@ type FlockEventRaw = {
   persons: Person[];
   costs: number;
   type: EventType;
-  defaultTimeAllocationType?: AllocationType | null;
 };
 
 // The type we send to the backend: the generated wirespec contract.
@@ -87,7 +85,6 @@ const internalizeFull = (it: FlockEventRaw): FullFlockEvent => ({
   id: it.id,
   days: it.days,
   costs: it.costs,
-  defaultTimeAllocationType: it.defaultTimeAllocationType,
 });
 
 export const EVENT_PAGE_SIZE: number = 10;

--- a/workday-application/src/main/react/features/event/EventDialog.tsx
+++ b/workday-application/src/main/react/features/event/EventDialog.tsx
@@ -32,7 +32,6 @@ export function EventDialog({ open, code, onComplete }: EventDialogProps) {
           setState({
             ...res,
             personIds: res.persons.map((it) => it.uuid) ?? [],
-            defaultTimeAllocationType: res.defaultTimeAllocationType ?? '',
           });
         });
       } else {
@@ -53,7 +52,6 @@ export function EventDialog({ open, code, onComplete }: EventDialogProps) {
       costs: it.costs,
       personIds: it.personIds,
       type: it.type,
-      defaultTimeAllocationType: it.defaultTimeAllocationType || undefined,
     };
     const persist = code ? EventClient.put(code, body) : EventClient.post(body);
     persist.then((res) => {

--- a/workday-application/src/main/react/features/event/EventForm.tsx
+++ b/workday-application/src/main/react/features/event/EventForm.tsx
@@ -1,4 +1,4 @@
-import { MenuItem } from '@mui/material';
+import { Typography } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import dayjs from 'dayjs';
 import { Field, Form, Formik, type FormikProps } from 'formik';
@@ -8,7 +8,10 @@ import * as Yup from 'yup';
 import { DatePickerField } from '../../components/fields/DatePickerField';
 import { PeriodInputField } from '../../components/fields/PeriodInputField';
 import { PersonSelectorField } from '../../components/fields/PersonSelectorField';
-import { EventTypeMappingToBillable } from '../../utils/mappings';
+import {
+  EventTypeBudgetLabel,
+  EventTypeMappingToBillable,
+} from '../../utils/mappings';
 import { mutatePeriod } from '../period/Period';
 import { EventTypeSelect } from './EventTypeSelect';
 
@@ -26,7 +29,6 @@ const schema = Yup.object().shape({
   personIds: Yup.array().default([]),
   costs: Yup.number().required().min(0).default(0),
   type: Yup.string().required('Field required').default('GENERAL_EVENT'),
-  defaultTimeAllocationType: Yup.string().nullable().default(''),
 });
 
 type EventFormProps = {
@@ -41,12 +43,13 @@ type EventFormFieldsProps = {
 
 function EventFormFields({ values, setFieldValue }: EventFormFieldsProps) {
   const [resetHours, setResetHours] = useState<boolean>(false);
-  const isExistingEvent = Boolean(values.code);
 
   const handleEventTypeChange = (newValue: string) => {
     setFieldValue('type', newValue);
     setResetHours(EventTypeMappingToBillable[newValue]);
   };
+
+  const budgetLabel = EventTypeBudgetLabel[values.type];
 
   return (
     <Form id={EVENT_FORM_ID}>
@@ -60,7 +63,7 @@ function EventFormFields({ values, setFieldValue }: EventFormFieldsProps) {
             component={TextField}
           />
         </Grid>
-        <Grid size={{ xs: 6 }}>
+        <Grid size={{ xs: 12 }}>
           <Field
             name="costs"
             type="number"
@@ -68,25 +71,6 @@ function EventFormFields({ values, setFieldValue }: EventFormFieldsProps) {
             fullWidth
             component={TextField}
           />
-        </Grid>
-        <Grid size={{ xs: 6 }}>
-          <Field
-            name="defaultTimeAllocationType"
-            label="Event type"
-            select
-            fullWidth
-            disabled={isExistingEvent}
-            helperText={
-              isExistingEvent
-                ? "Event type can't be changed after creation"
-                : undefined
-            }
-            component={TextField}
-          >
-            <MenuItem value="">None</MenuItem>
-            <MenuItem value="HACK">Hack</MenuItem>
-            <MenuItem value="TRAINING">Training</MenuItem>
-          </Field>
         </Grid>
         <Grid size={{ xs: 12 }}>
           <PersonSelectorField name="personIds" multiple fullWidth />
@@ -96,6 +80,15 @@ function EventFormFields({ values, setFieldValue }: EventFormFieldsProps) {
             value={values.type}
             onChange={handleEventTypeChange}
           />
+          {budgetLabel && (
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ mt: 0.5, display: 'block' }}
+            >
+              {budgetLabel}
+            </Typography>
+          )}
         </Grid>
         <Grid size={{ xs: 6 }}>
           <DatePickerField name="from" label="From" maxDate={values.to} />
@@ -126,7 +119,6 @@ export function EventForm({ value, onSubmit }: EventFormProps) {
       days: data.days,
       costs: data.costs,
       type: data.type,
-      defaultTimeAllocationType: data.defaultTimeAllocationType,
     });
   };
 

--- a/workday-application/src/main/react/utils/mappings.ts
+++ b/workday-application/src/main/react/utils/mappings.ts
@@ -13,3 +13,11 @@ export const EventTypeMappingToBillable: Record<EventType, boolean> = {
   [EventType.FLOCK_COMMUNITY_DAY]: true,
   [EventType.CONFERENCE]: false,
 };
+
+// Mirrors backend EventType.defaultAllocationType(); keep in sync.
+export const EventTypeBudgetLabel: Record<EventType, string | null> = {
+  [EventType.GENERAL_EVENT]: null,
+  [EventType.FLOCK_HACK_DAY]: 'Deducts from your hack day budget',
+  [EventType.FLOCK_COMMUNITY_DAY]: null,
+  [EventType.CONFERENCE]: 'Deducts from your training budget',
+};

--- a/workday-application/src/main/wirespec/events.ws
+++ b/workday-application/src/main/wirespec/events.ws
@@ -41,15 +41,11 @@ type Event {
   hours: Number?,
   costs: Number?,
   `type`: EventType?,
-  defaultTimeAllocationType: AllocationType?,
   days: Number[]?,
   persons: Person[]?
 }
 enum EventType {
   FLOCK_HACK_DAY, FLOCK_COMMUNITY_DAY, CONFERENCE, GENERAL_EVENT
-}
-enum AllocationType {
-  HACK, TRAINING
 }
 type EventForm {
   description: String?,
@@ -59,8 +55,7 @@ type EventForm {
   days: Number[]?,
   costs: Number?,
   personIds: String[]?,
-  `type`: EventFormType?,
-  defaultTimeAllocationType: AllocationType?
+  `type`: EventFormType?
 }
 enum EventFormType {
   FLOCK_HACK_DAY, FLOCK_COMMUNITY_DAY, CONFERENCE, GENERAL_EVENT

--- a/workday-application/src/test/kotlin/community/flock/eco/workday/helpers/CreateHelper.kt
+++ b/workday-application/src/test/kotlin/community/flock/eco/workday/helpers/CreateHelper.kt
@@ -10,7 +10,6 @@ import community.flock.eco.workday.application.forms.PersonForm
 import community.flock.eco.workday.application.forms.SickDayForm
 import community.flock.eco.workday.application.forms.WorkDayForm
 import community.flock.eco.workday.application.mappers.toDomain
-import community.flock.eco.workday.application.model.AllocationType
 import community.flock.eco.workday.application.model.Assignment
 import community.flock.eco.workday.application.model.Client
 import community.flock.eco.workday.application.model.EventType
@@ -233,7 +232,6 @@ class CreateHelper(
         persons: List<UUID>,
         costs: Double = 538.38,
         type: EventType = EventType.GENERAL_EVENT,
-        defaultTimeAllocationType: AllocationType? = null,
     ) = EventForm(
         description = "Very description",
         from = from,
@@ -243,7 +241,6 @@ class CreateHelper(
         personIds = persons,
         costs = costs,
         type = type,
-        defaultTimeAllocationType = defaultTimeAllocationType,
     ).run {
         eventService.create(this)
     }

--- a/workday-application/src/test/kotlin/community/flock/eco/workday/services/BudgetSummaryServiceTest.kt
+++ b/workday-application/src/test/kotlin/community/flock/eco/workday/services/BudgetSummaryServiceTest.kt
@@ -1,7 +1,6 @@
 package community.flock.eco.workday.services
 
 import community.flock.eco.workday.WorkdayIntegrationTest
-import community.flock.eco.workday.application.model.AllocationType
 import community.flock.eco.workday.application.model.EventType
 import community.flock.eco.workday.application.repository.EventDayRepository
 import community.flock.eco.workday.application.services.BudgetSummaryService
@@ -52,7 +51,6 @@ class BudgetSummaryServiceTest(
             persons = listOf(person.uuid),
             costs = 1000.0,
             type = EventType.CONFERENCE,
-            defaultTimeAllocationType = AllocationType.TRAINING,
         )
 
         val summary = budgetSummaryService.getSummary(person.uuid, year)
@@ -106,7 +104,6 @@ class BudgetSummaryServiceTest(
                 persons = listOf(one.uuid, two.uuid, three.uuid),
                 costs = 1000.0,
                 type = EventType.CONFERENCE,
-                defaultTimeAllocationType = AllocationType.TRAINING,
             )
 
         val costs =


### PR DESCRIPTION
Stacked on #536 (`feat/budget-allocations-eventday`) for discussion before folding in.

## Problem

The event add/edit dialog showed **"Event type" twice**: the existing `EventType` select (General event / Conference / Flock. Community Day / Flock. Hack Day) and #536's new HACK/TRAINING `defaultTimeAllocationType` selector.

## Change

Collapse to one dropdown — the budget marker is **derived from `EventType`**, and the stored `defaultTimeAllocationType` field is removed entirely.

| EventType | Budget |
|---|---|
| Flock. Hack Day | HACK |
| Conference | TRAINING |
| Flock. Community Day | – |
| General event | – |

A caption under the dropdown shows the impact live (e.g. *"Deducts from your training budget"*), so the mapping is visible without a second field.

## Schema effect (vs #536)

This branch **removes** a column — no new table, no new grain. It deletes changeset `034-budget-on-event-day-1` (the `event.default_time_allocation_type` addColumn) so that column **never lands**. The remaining `034-budget-on-event-day-0` (`event_day.cost`) is unchanged.

```mermaid
erDiagram
    EVENT ||--o{ EVENT_DAY : "has"
    EVENT {
        bigint id PK
        varchar type "budget marker now DERIVED from this"
        varchar default_time_allocation_type "REMOVED (column never created)"
    }
    EVENT_DAY {
        bigint id PK
        bigint event_id FK
        bigint person_id FK
        double hours
        decimal cost "from 034-...-0 (kept)"
    }
```

**Grain-fit:** no table added. The budget marker was a per-`event` scalar; it is now derived from the existing `event.type` column at read time (`Event.allocationType`), so the redundant column is dropped rather than stored. `event_day` keeps its grain (one row = one person's participation in one event).

## ⚠️ Decision to discuss

This **reverses #536's deliberate "marker is not reducible to EventType"** call (a self-booked study event was TRAINING, not CONFERENCE). Consequences accepted with the chosen mapping:
- **Every** conference now counts against training budget (previously only explicitly-marked ones).
- A `GENERAL_EVENT` can no longer be training — seed `"Personal study budget"` re-typed `GENERAL_EVENT → CONFERENCE`.

Alternative considered: add explicit budget event types (e.g. a "Training / Study" type) so nothing is lost. Happy to switch if conference-always-training is wrong.

## Verified

- `EventControllerTest` 7/7, `BudgetSummaryServiceTest` 3/3 — training assertions pass via `CONFERENCE` alone, confirming the derivation.
- `tsc --noEmit` clean; generated wirespec has no `AllocationType` / `defaultTimeAllocationType` leftovers; biome formatting clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
