### PR TITLE
fix: rebalance EventDay costs in place to avoid duplicate day code

### DIFF
--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/model/Day.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/model/Day.kt
@@ -27,7 +27,7 @@ abstract class Day(
     code: String = UUID.randomUUID().toString(),
     override val from: LocalDate = LocalDate.now(),
     override val to: LocalDate = LocalDate.now(),
-    override val hours: Double,
+    override var hours: Double,
     @ElementCollection(fetch = FetchType.EAGER)
     override val days: MutableList<Double>? = null,
 ) : AbstractCodeEntity(id, code),

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/model/EventDay.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/model/EventDay.kt
@@ -19,7 +19,7 @@ class EventDay(
     to: LocalDate = LocalDate.now(),
     hours: Double,
     days: MutableList<Double>? = null,
-    val cost: BigDecimal? = null,
+    var cost: BigDecimal? = null,
     @ManyToOne
     val person: Person,
     @ManyToOne

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/services/EventService.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/services/EventService.kt
@@ -73,7 +73,7 @@ class EventService(
                         eventDayRepository.save(event.eventDayFor(person, hours = hours ?: event.hours))
                         event.rebalanceCosts()
                     }
-                    hours != null && hours != existing.hours -> eventDayRepository.save(existing.with(hours = hours))
+                    hours != null && hours != existing.hours -> existing.hours = hours
                 }
             }?.refreshed()
             ?: error("Cannot subscribe to Event: $eventCode")
@@ -147,7 +147,7 @@ class EventService(
         val days = eventDayRepository.findAllByEventCode(code)
         if (days.isEmpty()) return
         val costShares = splitEvenly(total, days.size)
-        days.forEachIndexed { index, day -> eventDayRepository.save(day.with(cost = costShares[index])) }
+        days.forEachIndexed { index, day -> day.cost = costShares[index] }
     }
 
     private fun Event.eventDayFor(
@@ -162,21 +162,6 @@ class EventService(
         cost = cost,
         person = person,
         event = this,
-    )
-
-    private fun EventDay.with(
-        hours: Double = this.hours,
-        cost: BigDecimal? = this.cost,
-    ) = EventDay(
-        id = id,
-        code = code,
-        from = from,
-        to = to,
-        hours = hours,
-        days = days?.toMutableList(),
-        cost = cost,
-        person = person,
-        event = event,
     )
 
     private fun splitEvenly(


### PR DESCRIPTION
## Problem

Subscribing to a cost-bearing event intermittently returned **HTTP 500** with a `UC_DAYCODE` unique-constraint violation (`insert into "day" ... 23505`). It was deterministic per event in dev data (any hack day, which seeds `costs = 750`), but never reproduced in the integration tests.

### Root cause

`subscribeToEvent` → `rebalanceCosts()` (and the hours-override branch) rebuilt each `EventDay` through a `with()` copy helper and re-saved it:

```kotlin
days.forEachIndexed { i, day -> eventDayRepository.save(day.with(cost = costShares[i])) }
```

The copy reused the existing `id` and `code`. When the originals were loaded in a **fresh persistence context** — which is every real subscribe/unsubscribe request, but *not* the in-session test flow — Spring Data's `save()` routed the rebuilt copy through `persist` instead of `merge`. Hibernate then allocated a **new id from the sequence** while keeping the **old unique `code`**, producing an `INSERT` that collided with the row already in `day`.

Captured from the live SQL:

```
insert into "day" ("code","from","hours","to","id") values
  ('529af23a-...'  /* existing code */, '2026-01-14', 8.0, '2026-01-14', 438 /* new id */)
→ Unique index violation: PUBLIC.UC_DAYCODE ... '529af23a-...'
```

The seed path (`rebuildEventDaysFromTemplate`, delete-then-insert) never hit this, so seeded budgets looked correct while every runtime mutation was unreliable.

## Fix

Make `EventDay.cost` and `Day.hours` mutable and update the **managed** entities in place, letting JPA dirty-checking flush plain `UPDATE`s. The `EventDay.with()` helper is removed.

## Verification

- Existing `EventControllerTest` / `EventRepositoryTest` green (incl. *event cost stays split across subscribe and unsubscribe*).
- Manually against a running dev backend: subscribe/unsubscribe across all hack days now returns 200 (previously a deterministic 500 on the cost-bearing ones); subscribing two hack days at 4h moves the hack budget by 8h, and a €300 conference with a participant moves their training budget by +8h / +€300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)