### PR TITLE
fix: index event_day FK columns to restore home-page load speed

### DIFF
--- a/workday-application/src/main/database/db/changelog/db.changelog-034-event-day-indexes.yaml
+++ b/workday-application/src/main/database/db/changelog/db.changelog-034-event-day-indexes.yaml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+  - changeSet:
+      id: db.changelog-034-event-day-indexes-1
+      author: rkorver
+      comment: >-
+        Index event_day FK columns. findAllActiveByPerson filters by person_id
+        (via person.uuid), and Event's EAGER @OneToMany eventDays loads by
+        event_id — both scanned the full table without these indexes.
+      changes:
+        - createIndex:
+            indexName: event_day_person_id_index
+            tableName: event_day
+            columns:
+              - column:
+                  name: person_id
+        - createIndex:
+            indexName: event_day_event_id_index
+            tableName: event_day
+            columns:
+              - column:
+                  name: event_id

--- a/workday-application/src/main/database/db/changelog/db.changelog-master.yaml
+++ b/workday-application/src/main/database/db/changelog/db.changelog-master.yaml
@@ -97,4 +97,7 @@ databaseChangeLog:
   - include:
       file: db.changelog-033-budget-on-event-day.yaml
       relativeToChangelogFile: true
+  - include:
+      file: db.changelog-034-event-day-indexes.yaml
+      relativeToChangelogFile: true
 


### PR DESCRIPTION
## Problem

The home page got slow to load (and events are slow in the flock-app generally) after the EventDay work landed.

Root cause is a **missing index on the `event_day` foreign-key columns**:

- `db.changelog-030` created `event_day` with FK *constraints* on `person_id` and `event_id`, but **no indexes**. Postgres (prod) does **not** auto-index FK columns — H2 (dev) does, which is why this never reproduced locally.
- The #530 refactor replaced the old `event_persons` join table (whose columns were covered by a composite PK, i.e. indexed) with these bare FKs — that's the regression.
- #536 then put a per-person budget summary on the home page (`BudgetController.budgetSummary` → `BudgetSummaryService.getSummary` → `EventDayRepository.findAllActiveByPerson`), which joins/filters `event_day` by person on **every** home-page load.
- Separately, `Event.eventDays` is `@OneToMany(fetch = EAGER)`, so **any** `Event` read triggers an `event_day WHERE event_id IN (...)` fetch.

Both hot queries full-scanned `event_day` on prod.

## Fix

New Liquibase changeset `034` adds the two missing indexes:

- `event_day_person_id_index` on `event_day(person_id)` — speeds the per-person budget/aggregation queries.
- `event_day_event_id_index` on `event_day(event_id)` — speeds the EAGER `eventDays` fetch on every `Event` read.

Additive, idempotent (fresh changeset), portable `createIndex` with automatic `dropIndex` rollback.

## Schema

No new tables and no grain change — this only adds two indexes to the existing `event_day` table. Grain is unchanged: one `event_day` row = one person's participation in one event (natural key `(event_id, person_id)`), already the per-person aggregate introduced by #530.

```mermaid
erDiagram
    event ||--o{ event_day : "event_id (FK) [+idx]"
    person ||--o{ event_day : "person_id (FK) [+idx]"
    day ||--|| event_day : "id (joined-inheritance PK/FK)"

    event_day {
        bigint id PK "FK to day"
        bigint person_id FK "NEW index: event_day_person_id_index"
        bigint event_id FK "NEW index: event_day_event_id_index"
        decimal cost "added in #536"
    }
```

## Testing

- `./mvnw -pl workday-application clean test` → 233 tests, 0 errors. The one failure is the pre-existing nl_NL locale test (`WorkdayEmailServiceTest."Send notification"`), unrelated to this change and green under en_US (CI).
- The Spring Boot test context applies the new changeset on boot, so the suite exercises the migration.

## Notes

- Renumbered to `034` to avoid a `033` collision with #536's `033-budget-on-event-day`.
- The EAGER fetch on `Event.eventDays` is left as-is; the index addresses the immediate regression. Reconsidering that fetch strategy is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
