### PR TITLE
feat: per-attendee hours & cost breakdown on events (#540)

### DIFF
--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/BudgetController.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/BudgetController.kt
@@ -4,6 +4,7 @@ import community.flock.eco.workday.api.endpoint.BudgetSummary
 import community.flock.eco.workday.application.authorities.AggregationAuthority
 import community.flock.eco.workday.application.model.Person
 import community.flock.eco.workday.application.services.BudgetSummaryService
+import community.flock.eco.workday.application.services.PersonBudgetEvent
 import community.flock.eco.workday.application.services.PersonBudgetItem
 import community.flock.eco.workday.application.services.PersonBudgetSummary
 import community.flock.eco.workday.application.services.PersonService
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
 import java.time.LocalDate
 import java.util.UUID
+import community.flock.eco.workday.api.model.BudgetEvent as BudgetEventApi
 import community.flock.eco.workday.api.model.BudgetItem as BudgetItemApi
 import community.flock.eco.workday.api.model.BudgetSummaryResponse as BudgetSummaryResponseApi
 
@@ -67,6 +69,17 @@ private fun PersonBudgetSummary.produce(): BudgetSummaryResponseApi =
         hackTimeBudget = hackTimeBudget.produce(),
         trainingTimeBudget = trainingTimeBudget.produce(),
         trainingMoneyBudget = trainingMoneyBudget.produce(),
+        events = events.map { it.produce() },
+    )
+
+private fun PersonBudgetEvent.produce(): BudgetEventApi =
+    BudgetEventApi(
+        eventCode = eventCode,
+        description = description,
+        from = from.toString(),
+        hours = hours,
+        cost = cost?.toDouble(),
+        category = category.name,
     )
 
 private fun PersonBudgetItem.produce(): BudgetItemApi =

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/EventController.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/EventController.kt
@@ -12,9 +12,11 @@ import community.flock.eco.workday.api.endpoint.PutEvent
 import community.flock.eco.workday.api.endpoint.SubscribeToEvent
 import community.flock.eco.workday.api.endpoint.UnsubscribeFromEvent
 import community.flock.eco.workday.application.authorities.EventAuthority
+import community.flock.eco.workday.application.forms.EventDayInput
 import community.flock.eco.workday.application.forms.EventForm
 import community.flock.eco.workday.application.forms.EventRatingForm
 import community.flock.eco.workday.application.model.Event
+import community.flock.eco.workday.application.model.EventDay
 import community.flock.eco.workday.application.model.EventRating
 import community.flock.eco.workday.application.model.EventType
 import community.flock.eco.workday.application.model.Person
@@ -31,9 +33,12 @@ import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.util.UUID
 import community.flock.eco.workday.api.model.Event as EventApi
+import community.flock.eco.workday.api.model.EventDay as EventDayApi
+import community.flock.eco.workday.api.model.EventDayForm as EventDayFormApi
 import community.flock.eco.workday.api.model.EventForm as EventFormApi
 import community.flock.eco.workday.api.model.EventFormType as EventFormTypeApi
 import community.flock.eco.workday.api.model.EventProjection as EventProjectionApi
@@ -199,8 +204,18 @@ class EventController(
             days = days?.toMutableList() ?: mutableListOf(),
             costs = costs ?: 0.0,
             personIds = personIds?.map(UUID::fromString) ?: emptyList(),
+            participants = participants?.mapNotNull { it.internalize() } ?: emptyList(),
             type = type?.toDomain() ?: EventType.GENERAL_EVENT,
         )
+
+    private fun EventDayFormApi.internalize(): EventDayInput? {
+        val personId = personId?.let(UUID::fromString) ?: return null
+        return EventDayInput(
+            personId = personId,
+            hours = hours ?: 0.0,
+            cost = cost?.let { BigDecimal.valueOf(it) },
+        )
+    }
 
     private fun Event.externalize(): EventApi =
         EventApi(
@@ -214,6 +229,14 @@ class EventController(
             type = type.toApi(),
             days = days,
             persons = persons.map { it.externalize() },
+            eventDays = eventDays.map { it.externalize() },
+        )
+
+    private fun EventDay.externalize(): EventDayApi =
+        EventDayApi(
+            personId = person.uuid.toString(),
+            hours = hours,
+            cost = cost?.toDouble(),
         )
 
     private fun EventRating.externalize(): EventRatingApi =

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/EventController.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/EventController.kt
@@ -214,6 +214,7 @@ class EventController(
             personId = personId,
             hours = hours ?: 0.0,
             cost = cost?.let { BigDecimal.valueOf(it) },
+            days = days,
         )
     }
 
@@ -237,6 +238,7 @@ class EventController(
             personId = person.uuid.toString(),
             hours = hours,
             cost = cost?.toDouble(),
+            days = days,
         )
 
     private fun EventRating.externalize(): EventRatingApi =

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/forms/EventForm.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/forms/EventForm.kt
@@ -31,4 +31,6 @@ data class EventDayInput(
     val personId: UUID,
     val hours: Double,
     val cost: BigDecimal? = null,
+    // Per-day hours over the event's date range; when null the person inherits the event blueprint.
+    val days: List<Double>? = null,
 )

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/forms/EventForm.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/forms/EventForm.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer
 import community.flock.eco.workday.application.interfaces.Daily
 import community.flock.eco.workday.application.model.EventType
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.util.UUID
 
@@ -21,5 +22,13 @@ data class EventForm(
     override val days: MutableList<Double>,
     val costs: Double,
     val personIds: List<UUID>,
+    // When non-empty, takes precedence over personIds as the source of truth for membership, hours and cost.
+    val participants: List<EventDayInput> = emptyList(),
     val type: EventType,
 ) : Daily
+
+data class EventDayInput(
+    val personId: UUID,
+    val hours: Double,
+    val cost: BigDecimal? = null,
+)

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/services/BudgetSummaryService.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/services/BudgetSummaryService.kt
@@ -34,10 +34,26 @@ class BudgetSummaryService(
         val trainingHoursUsed = trainingDays.sumOf { it.hours }.toBigDecimal()
         val trainingMoneyUsed = trainingDays.sumOf { it.cost ?: BigDecimal.ZERO }
 
+        val budgetBearingDays = hackDays + trainingDays
+        val events =
+            budgetBearingDays
+                .sortedBy { it.event.from }
+                .map { day ->
+                    PersonBudgetEvent(
+                        eventCode = day.event.code,
+                        description = day.event.description,
+                        from = day.event.from,
+                        hours = day.hours,
+                        cost = day.cost,
+                        category = day.event.budgetCategory!!,
+                    )
+                }
+
         return PersonBudgetSummary(
             hackTimeBudget = PersonBudgetItem(hackHoursBudget, hackHoursUsed),
             trainingTimeBudget = PersonBudgetItem(trainingHoursBudget, trainingHoursUsed),
             trainingMoneyBudget = PersonBudgetItem(trainingMoneyBudget, trainingMoneyUsed),
+            events = events,
         )
     }
 }
@@ -46,6 +62,16 @@ data class PersonBudgetSummary(
     val hackTimeBudget: PersonBudgetItem,
     val trainingTimeBudget: PersonBudgetItem,
     val trainingMoneyBudget: PersonBudgetItem,
+    val events: List<PersonBudgetEvent>,
+)
+
+data class PersonBudgetEvent(
+    val eventCode: String,
+    val description: String,
+    val from: LocalDate,
+    val hours: Double,
+    val cost: BigDecimal?,
+    val category: BudgetCategory,
 )
 
 data class PersonBudgetItem(

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/services/EventService.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/services/EventService.kt
@@ -139,6 +139,7 @@ class EventService(
                     person = person,
                     cost = participant.cost?.setScale(2, RoundingMode.HALF_UP),
                     hours = participant.hours,
+                    days = participant.days?.toMutableList() ?: days?.toMutableList(),
                 ),
             )
         }
@@ -179,11 +180,12 @@ class EventService(
         person: Person,
         cost: BigDecimal? = null,
         hours: Double = this.hours,
+        days: MutableList<Double>? = this.days?.toMutableList(),
     ) = EventDay(
         from = from,
         to = to,
         hours = hours,
-        days = days?.toMutableList(),
+        days = days,
         cost = cost,
         person = person,
         event = this,

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/services/EventService.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/services/EventService.kt
@@ -1,5 +1,6 @@
 package community.flock.eco.workday.application.services
 
+import community.flock.eco.workday.application.forms.EventDayInput
 import community.flock.eco.workday.application.forms.EventForm
 import community.flock.eco.workday.application.interfaces.validate
 import community.flock.eco.workday.application.model.Event
@@ -114,9 +115,33 @@ class EventService(
                     type = type,
                 ),
             )
-        val persons = personService.findByPersonCodeIdIn(personIds).toList()
-        event.rebuildEventDaysFromTemplate(persons, previousHours)
+        if (participants.isNotEmpty()) {
+            event.rebuildEventDaysFromParticipants(participants)
+        } else {
+            val persons = personService.findByPersonCodeIdIn(personIds).toList()
+            event.rebuildEventDaysFromTemplate(persons, previousHours)
+        }
         return event.refreshed()
+    }
+
+    // Per-attendee hours and cost arrive already balanced from the admin modal (cost shares
+    // sum to the event total); persist them verbatim, only normalizing money to whole cents.
+    private fun Event.rebuildEventDaysFromParticipants(participants: List<EventDayInput>) {
+        eventDayRepository.deleteAll(eventDayRepository.findAllByEventCode(code))
+        val personsById =
+            personService
+                .findByPersonCodeIdIn(participants.map { it.personId }.distinct())
+                .associateBy { it.uuid }
+        participants.forEach { participant ->
+            val person = personsById[participant.personId] ?: return@forEach
+            eventDayRepository.save(
+                eventDayFor(
+                    person = person,
+                    cost = participant.cost?.setScale(2, RoundingMode.HALF_UP),
+                    hours = participant.hours,
+                ),
+            )
+        }
     }
 
     // Override detected by hours diverging from the previous default, not by membership: the

--- a/workday-application/src/main/react/application/ApplicationLayout.tsx
+++ b/workday-application/src/main/react/application/ApplicationLayout.tsx
@@ -161,7 +161,8 @@ export function ApplicationLayout({ onDrawer }: ApplicationLayoutProps) {
             </Button>
           }
         >
-          Extend your session or be redirected you peasant.
+          Quick heads up: your session's almost up. Extend it to stick around,
+          or log back in.
         </Alert>
       </Snackbar>
     </Root>

--- a/workday-application/src/main/react/clients/EventClient.ts
+++ b/workday-application/src/main/react/clients/EventClient.ts
@@ -22,6 +22,7 @@ export type FlockEventDay = {
   personId: string;
   hours: number;
   cost: number | null;
+  days?: number[];
 };
 
 export type FullFlockEvent = {

--- a/workday-application/src/main/react/clients/EventClient.ts
+++ b/workday-application/src/main/react/clients/EventClient.ts
@@ -18,6 +18,12 @@ export type FlockEvent = {
   type: EventType;
 };
 
+export type FlockEventDay = {
+  personId: string;
+  hours: number;
+  cost: number | null;
+};
+
 export type FullFlockEvent = {
   id: number;
   description: string;
@@ -27,6 +33,7 @@ export type FullFlockEvent = {
   hours: number;
   days: number[];
   persons: Person[];
+  eventDays: FlockEventDay[];
   costs: number;
   type: EventType;
 };
@@ -50,6 +57,7 @@ type FlockEventRaw = {
   hours: number;
   days: number[];
   persons: Person[];
+  eventDays?: FlockEventDay[];
   costs: number;
   type: EventType;
 };
@@ -81,6 +89,7 @@ const internalizeFull = (it: FlockEventRaw): FullFlockEvent => ({
   to: dayjs(it.to),
   hours: it.hours,
   persons: it.persons,
+  eventDays: it.eventDays ?? [],
   type: it.type,
   id: it.id,
   days: it.days,

--- a/workday-application/src/main/react/components/fields/PeriodInputField.tsx
+++ b/workday-application/src/main/react/components/fields/PeriodInputField.tsx
@@ -32,6 +32,8 @@ type PeriodInputFieldProps = {
   to: dayjs.Dayjs;
   reset?: boolean;
   dayMeta?: Map<string, DayMeta>;
+  weekLabel?: boolean;
+  hideWeekTotal?: boolean;
 };
 
 function PeriodInputRenderer({
@@ -42,6 +44,8 @@ function PeriodInputRenderer({
   value,
   setFieldValue,
   dayMeta,
+  weekLabel,
+  hideWeekTotal,
 }: Readonly<PeriodInputRendererProps>) {
   const [period, setPeriod] = useState<Period>({
     from,
@@ -90,6 +94,8 @@ function PeriodInputRenderer({
         period={period}
         onChange={handlePeriodChange}
         dayMeta={dayMeta}
+        weekLabel={weekLabel}
+        hideWeekTotal={hideWeekTotal}
       />
       <ButtonGroup className={classes.buttons} size="small" fullWidth>
         <Button variant="outlined" onClick={() => setHoursPerDay(0)}>
@@ -114,6 +120,8 @@ type PeriodInputRendererProps = {
   value: any;
   setFieldValue: (field: string, value: unknown) => void;
   dayMeta?: Map<string, DayMeta>;
+  weekLabel?: boolean;
+  hideWeekTotal?: boolean;
 };
 
 export function PeriodInputField({
@@ -122,6 +130,8 @@ export function PeriodInputField({
   to,
   reset,
   dayMeta,
+  weekLabel,
+  hideWeekTotal,
 }: Readonly<PeriodInputFieldProps>) {
   return (
     <StyledField id={name} name={name}>
@@ -134,6 +144,8 @@ export function PeriodInputField({
           value={value}
           setFieldValue={setFieldValue}
           dayMeta={dayMeta}
+          weekLabel={weekLabel}
+          hideWeekTotal={hideWeekTotal}
         />
       )}
     </StyledField>

--- a/workday-application/src/main/react/components/inputs/PeriodInput.tsx
+++ b/workday-application/src/main/react/components/inputs/PeriodInput.tsx
@@ -3,6 +3,7 @@ import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import dayjs, { type Dayjs } from 'dayjs';
 import weekOfYearPlugin from 'dayjs/plugin/weekOfYear';
+import { Fragment, type ReactNode } from 'react';
 import type { Period } from '../../features/period/Period';
 import type { DayMeta } from '../../hooks/DayMetaHook';
 
@@ -13,10 +14,17 @@ dayjs.extend(weekOfYearPlugin);
 
 const daysOfWeek = ['Ma', 'Di', 'Wo', 'Do', 'Vr', 'Za', 'Zo'];
 
+type GridDay = { key: string; date: Dayjs; disabled: boolean; value: string };
+
 export type PeriodInputProps = {
   period: Period;
   onChange: (day: Dayjs, hours: number) => void;
   dayMeta?: Map<string, DayMeta>;
+  weekLabel?: boolean;
+  hideWeekTotal?: boolean;
+  hidePeriodTotal?: boolean;
+  trailingHeader?: ReactNode;
+  renderTrailing?: (weekIndex: number) => ReactNode;
 };
 
 // Background-only fill — green for hackdays, purple for leave (no
@@ -46,13 +54,190 @@ const tooltipFor = (meta: DayMeta | undefined): string | undefined => {
   return parts.length > 0 ? parts.join(' · ') : undefined;
 };
 
-export function PeriodInput({ period, onChange, dayMeta }: PeriodInputProps) {
+function DayField({
+  day,
+  meta,
+  onChange,
+  fullWidth,
+}: {
+  day: GridDay;
+  meta: DayMeta | undefined;
+  onChange: (day: Dayjs, hours: number) => void;
+  fullWidth?: boolean;
+}) {
+  const background = backgroundFor(meta);
+  const tooltip = tooltipFor(meta);
+  const sx = background
+    ? { '& .MuiOutlinedInput-root': { backgroundColor: background } }
+    : undefined;
+  const field = (
+    <TextField
+      size="small"
+      label={day.disabled ? '-' : day.date.format('DD MMM')}
+      value={day.value}
+      disabled={day.disabled}
+      onChange={(ev) => onChange(day.date, parseFloat(ev.target.value || '0'))}
+      type="number"
+      sx={sx}
+      fullWidth={fullWidth}
+    />
+  );
+  if (!tooltip) return field;
+  return (
+    <Tooltip title={tooltip} arrow>
+      <span style={fullWidth ? { width: '100%', display: 'block' } : undefined}>
+        {field}
+      </span>
+    </Tooltip>
+  );
+}
+
+export function PeriodInput({
+  period,
+  onChange,
+  dayMeta,
+  weekLabel,
+  hideWeekTotal,
+  hidePeriodTotal,
+  trailingHeader,
+  renderTrailing,
+}: PeriodInputProps) {
   const grid = calcGrid(period);
 
   const totalHoursForPeriod = period.days?.reduce(
     (previous, current) => previous + current,
     0,
   );
+
+  const hasTrailing = renderTrailing !== undefined;
+  const showWeekTotal = !hideWeekTotal;
+
+  if (weekLabel || hideWeekTotal || hasTrailing) {
+    const weekColW = weekLabel ? '72px' : 'minmax(36px, max-content)';
+    const rightColW = showWeekTotal ? 'minmax(48px, max-content)' : '120px';
+    const template = [weekColW, 'repeat(7, minmax(0, 1fr))', rightColW]
+      .filter(Boolean)
+      .join(' ');
+    const trailingSx = hasTrailing ? { pl: 3 } : undefined;
+
+    return (
+      <>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: template,
+            columnGap: 1,
+            rowGap: 0,
+            alignItems: 'stretch',
+          }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            {!weekLabel && (
+              <Typography variant="body2" color="text.secondary">
+                Week
+              </Typography>
+            )}
+          </Box>
+          {daysOfWeek.map((d) => (
+            <Box
+              key={`day-name-${d}`}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <Typography variant="body2" color="text.secondary">
+                {d}
+              </Typography>
+            </Box>
+          ))}
+          {rightColW && (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: hasTrailing ? 'flex-start' : 'flex-end',
+                ...trailingSx,
+              }}
+            >
+              {hasTrailing && (
+                <Typography variant="body2" color="text.secondary">
+                  {trailingHeader}
+                </Typography>
+              )}
+              {showWeekTotal && (
+                <Typography variant="body2" color="text.secondary">
+                  Total
+                </Typography>
+              )}
+            </Box>
+          )}
+
+          {grid.map((week, weekIndex) => {
+            const trailingNode = hasTrailing ? renderTrailing(weekIndex) : null;
+            return (
+              <Fragment key={`${week.year} week-${week.weekNumber}`}>
+                <Box sx={{ display: 'flex', alignItems: 'center', py: 0.75 }}>
+                  <Typography variant="body2">
+                    {weekLabel ? `Week ${week.weekNumber}` : week.weekNumber}
+                  </Typography>
+                </Box>
+                {week.days?.map((day) => (
+                  <Box
+                    key={`day-${day.key}`}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      py: 0.75,
+                    }}
+                  >
+                    <DayField
+                      day={day}
+                      meta={day.disabled ? undefined : dayMeta?.get(day.key)}
+                      onChange={onChange}
+                      fullWidth
+                    />
+                  </Box>
+                ))}
+                {rightColW && (
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: hasTrailing ? 'stretch' : 'flex-end',
+                      py: 0.75,
+                      ...trailingSx,
+                    }}
+                  >
+                    {hasTrailing && trailingNode}
+                    {showWeekTotal && (
+                      <Typography variant="body2">{week.total}</Typography>
+                    )}
+                  </Box>
+                )}
+              </Fragment>
+            );
+          })}
+        </Box>
+        {!hidePeriodTotal && (
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+              gap: 3,
+              mt: 1.5,
+              pr: 0.5,
+            }}
+          >
+            <Typography color="text.secondary">Period total</Typography>
+            <Typography>{totalHoursForPeriod}</Typography>
+          </Box>
+        )}
+      </>
+    );
+  }
 
   return (
     <>
@@ -86,42 +271,15 @@ export function PeriodInput({ period, onChange, dayMeta }: PeriodInputProps) {
             <Grid size={{ xs: 2 }}>
               <Typography>{week.weekNumber}</Typography>
             </Grid>
-            {week.days?.map((day) => {
-              const meta = day.disabled ? undefined : dayMeta?.get(day.key);
-              const background = backgroundFor(meta);
-              const tooltip = tooltipFor(meta);
-              const sx = background
-                ? {
-                    '& .MuiOutlinedInput-root': {
-                      backgroundColor: background,
-                    },
-                  }
-                : undefined;
-              const field = (
-                <TextField
-                  size="small"
-                  label={day.disabled ? '-' : day.date.format('DD MMM')}
-                  value={day.value}
-                  disabled={day.disabled}
-                  onChange={(ev) =>
-                    onChange(day.date, parseFloat(ev.target.value || '0'))
-                  }
-                  type="number"
-                  sx={sx}
+            {week.days?.map((day) => (
+              <Grid size="grow" key={`day-${day.key}`}>
+                <DayField
+                  day={day}
+                  meta={day.disabled ? undefined : dayMeta?.get(day.key)}
+                  onChange={onChange}
                 />
-              );
-              return (
-                <Grid size="grow" key={`day-${day.key}`}>
-                  {tooltip ? (
-                    <Tooltip title={tooltip} arrow>
-                      <span>{field}</span>
-                    </Tooltip>
-                  ) : (
-                    field
-                  )}
-                </Grid>
-              );
-            })}
+              </Grid>
+            ))}
             <Grid size={{ xs: 2 }}>
               <Typography align="right">{week.total}</Typography>
             </Grid>

--- a/workday-application/src/main/react/features/budget/BudgetEventsTable.tsx
+++ b/workday-application/src/main/react/features/budget/BudgetEventsTable.tsx
@@ -1,0 +1,91 @@
+import {
+  Card,
+  CardContent,
+  Chip,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import type { BudgetEvent } from '../../wirespec/model';
+
+interface BudgetEventsTableProps {
+  events: BudgetEvent[];
+  onEditEvent?: (eventCode: string) => void;
+}
+
+const euro = (value: number) =>
+  value.toLocaleString('nl-NL', { style: 'currency', currency: 'EUR' });
+
+const date = (iso: string) =>
+  new Date(iso).toLocaleDateString('nl-NL', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+
+const categoryLabel: Record<string, string> = {
+  HACK: 'Hack',
+  TRAINING: 'Training',
+};
+
+export function BudgetEventsTable({
+  events,
+  onEditEvent,
+}: Readonly<BudgetEventsTableProps>) {
+  if (events.length === 0) return null;
+
+  return (
+    <Card>
+      <CardContent>
+        <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+          Events
+        </Typography>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Event</TableCell>
+              <TableCell>Date</TableCell>
+              <TableCell>Budget</TableCell>
+              <TableCell align="right">Hours</TableCell>
+              <TableCell align="right">Cost</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {events.map((event) => (
+              <TableRow
+                key={`${event.eventCode}-${event.category}`}
+                hover={Boolean(onEditEvent)}
+                onClick={
+                  onEditEvent ? () => onEditEvent(event.eventCode) : undefined
+                }
+                sx={onEditEvent ? { cursor: 'pointer' } : undefined}
+              >
+                <TableCell>{event.description}</TableCell>
+                <TableCell>{date(event.from)}</TableCell>
+                <TableCell>
+                  <Chip
+                    size="small"
+                    variant="outlined"
+                    label={categoryLabel[event.category] ?? event.category}
+                  />
+                </TableCell>
+                <TableCell align="right">
+                  {event.hours.toLocaleString('nl-NL', {
+                    maximumFractionDigits: 1,
+                  })}
+                  h
+                </TableCell>
+                <TableCell align="right">
+                  {event.category === 'TRAINING' ? euro(event.cost ?? 0) : '—'}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/workday-application/src/main/react/features/budget/BudgetFeature.tsx
+++ b/workday-application/src/main/react/features/budget/BudgetFeature.tsx
@@ -10,7 +10,10 @@ import {
 import { useCallback, useEffect, useState } from 'react';
 import { BudgetClient } from '../../clients/BudgetClient';
 import type { Person } from '../../clients/PersonClient';
+import { useUserMe } from '../../hooks/UserMeHook';
 import type { BudgetSummaryResponse } from '../../wirespec/model';
+import { EventDialog } from '../event/EventDialog';
+import { BudgetEventsTable } from './BudgetEventsTable';
 import { BudgetSummaryCards } from './BudgetSummaryCards';
 
 const currentYear = new Date().getFullYear();
@@ -21,9 +24,15 @@ type BudgetFeatureProps = {
 };
 
 export function BudgetFeature({ person }: BudgetFeatureProps) {
+  const [user] = useUserMe();
   const [year, setYear] = useState(currentYear);
   const [summary, setSummary] = useState<BudgetSummaryResponse | null>(null);
   const [error, setError] = useState(false);
+  const [editCode, setEditCode] = useState<string | undefined>(undefined);
+
+  const canEditEvents = Boolean(
+    user?.authorities?.includes('EventAuthority.WRITE'),
+  );
 
   const loadSummary = useCallback(() => {
     setSummary(null);
@@ -36,6 +45,11 @@ export function BudgetFeature({ person }: BudgetFeatureProps) {
   useEffect(() => {
     loadSummary();
   }, [loadSummary]);
+
+  const handleDialogComplete = () => {
+    setEditCode(undefined);
+    loadSummary();
+  };
 
   return (
     <Stack spacing={2}>
@@ -67,8 +81,21 @@ export function BudgetFeature({ person }: BudgetFeatureProps) {
       {error ? (
         <Alert severity="error">Could not load the budget summary.</Alert>
       ) : (
-        <BudgetSummaryCards summary={summary} />
+        <>
+          <BudgetSummaryCards summary={summary} />
+          {summary && (
+            <BudgetEventsTable
+              events={summary.events}
+              onEditEvent={canEditEvents ? setEditCode : undefined}
+            />
+          )}
+        </>
       )}
+      <EventDialog
+        open={Boolean(editCode)}
+        code={editCode}
+        onComplete={handleDialogComplete}
+      />
     </Stack>
   );
 }

--- a/workday-application/src/main/react/features/event/EventDialog.tsx
+++ b/workday-application/src/main/react/features/event/EventDialog.tsx
@@ -7,7 +7,11 @@ import { ConfirmDialog } from '@workday-core/components/ConfirmDialog';
 import { DialogFooter, DialogHeader } from '@workday-core/components/dialog';
 import { DialogBody } from '@workday-core/components/dialog/DialogHeader';
 import { useEffect, useState } from 'react';
-import { EventClient, type FlockEventRequest } from '../../clients/EventClient';
+import {
+  EventClient,
+  EventType,
+  type FlockEventRequest,
+} from '../../clients/EventClient';
 import { ISO_8601_DATE } from '../../clients/util/DateFormats';
 import { TransitionSlider } from '../../components/transitions/Slide';
 import { schema } from '../workday/WorkDayForm';
@@ -43,6 +47,7 @@ export function EventDialog({ open, code, onComplete }: EventDialogProps) {
   }, [open, code]);
 
   const handleSubmit = (it) => {
+    const moneyBearing = it.type !== EventType.FLOCK_HACK_DAY;
     const body: FlockEventRequest = {
       description: it.description,
       from: it.from.format(ISO_8601_DATE),
@@ -51,6 +56,11 @@ export function EventDialog({ open, code, onComplete }: EventDialogProps) {
       days: it.days,
       costs: it.costs,
       personIds: it.personIds,
+      participants: (it.participants ?? []).map((p) => ({
+        personId: p.personId,
+        hours: p.hours,
+        cost: moneyBearing ? (p.cost ?? 0) : null,
+      })),
       type: it.type,
     };
     const persist = code ? EventClient.put(code, body) : EventClient.post(body);

--- a/workday-application/src/main/react/features/event/EventDialog.tsx
+++ b/workday-application/src/main/react/features/event/EventDialog.tsx
@@ -48,19 +48,26 @@ export function EventDialog({ open, code, onComplete }: EventDialogProps) {
 
   const handleSubmit = (it) => {
     const moneyBearing = it.type !== EventType.FLOCK_HACK_DAY;
+    const blueprint: number[] = it.days ?? [];
+    const multiDay = blueprint.length > 1;
     const body: FlockEventRequest = {
       description: it.description,
       from: it.from.format(ISO_8601_DATE),
       to: it.to.format(ISO_8601_DATE),
-      hours: it.days.reduce((acc, cur) => acc + parseFloat(cur || 0), 0),
+      hours: blueprint.reduce((acc, cur) => acc + (Number(cur) || 0), 0),
       days: it.days,
       costs: it.costs,
       personIds: it.personIds,
-      participants: (it.participants ?? []).map((p) => ({
-        personId: p.personId,
-        hours: p.hours,
-        cost: moneyBearing ? (p.cost ?? 0) : null,
-      })),
+      participants: (it.participants ?? []).map((p) => {
+        const days = p.days ?? (multiDay ? blueprint : [p.hours]);
+        const hours = days.reduce((acc, cur) => acc + (Number(cur) || 0), 0);
+        return {
+          personId: p.personId,
+          hours,
+          cost: moneyBearing ? (p.cost ?? 0) : null,
+          days,
+        };
+      }),
       type: it.type,
     };
     const persist = code ? EventClient.put(code, body) : EventClient.post(body);

--- a/workday-application/src/main/react/features/event/EventForm.tsx
+++ b/workday-application/src/main/react/features/event/EventForm.tsx
@@ -5,6 +5,7 @@ import { Field, Form, Formik, type FormikProps } from 'formik';
 import { TextField } from 'formik-mui';
 import { useState } from 'react';
 import * as Yup from 'yup';
+import type { EventType } from '../../clients/EventClient';
 import { DatePickerField } from '../../components/fields/DatePickerField';
 import { PeriodInputField } from '../../components/fields/PeriodInputField';
 import { PersonSelectorField } from '../../components/fields/PersonSelectorField';
@@ -13,7 +14,13 @@ import {
   EventTypeMappingToBillable,
 } from '../../utils/mappings';
 import { mutatePeriod } from '../period/Period';
+import { EventParticipants, initParticipants } from './EventParticipants';
 import { EventTypeSelect } from './EventTypeSelect';
+
+const sumHours = (days: unknown): number =>
+  Array.isArray(days)
+    ? days.reduce<number>((acc, cur) => acc + (Number(cur) || 0), 0)
+    : 0;
 
 export const EVENT_FORM_ID = 'event-form';
 
@@ -27,6 +34,7 @@ const schema = Yup.object().shape({
     .default(() => dayjs()),
   days: Yup.array().default([8]).nullable(),
   personIds: Yup.array().default([]),
+  participants: Yup.array().default([]),
   costs: Yup.number().required().min(0).default(0),
   type: Yup.string().required('Field required').default('GENERAL_EVENT'),
 });
@@ -75,6 +83,17 @@ function EventFormFields({ values, setFieldValue }: EventFormFieldsProps) {
         <Grid size={{ xs: 12 }}>
           <PersonSelectorField name="personIds" multiple fullWidth />
         </Grid>
+        <Grid size={{ xs: 12 }}>
+          <EventParticipants
+            personIds={values.personIds ?? []}
+            participants={values.participants ?? []}
+            defaultHours={sumHours(values.days)}
+            total={Number(values.costs) || 0}
+            type={values.type}
+            knownPersons={values.persons}
+            setFieldValue={setFieldValue}
+          />
+        </Grid>
         <Grid size={{ xs: 12 }} style={{ marginTop: '1rem' }}>
           <EventTypeSelect
             value={values.type}
@@ -114,6 +133,7 @@ export function EventForm({ value, onSubmit }: EventFormProps) {
     onSubmit?.({
       description: data.description,
       personIds: data.personIds,
+      participants: data.participants,
       from: data.from,
       to: data.to,
       days: data.days,
@@ -122,7 +142,16 @@ export function EventForm({ value, onSubmit }: EventFormProps) {
     });
   };
 
-  const init = { ...schema.getDefault(), ...mutatePeriod(value) };
+  const base = { ...schema.getDefault(), ...mutatePeriod(value) };
+  const init = {
+    ...base,
+    participants: initParticipants(
+      value.eventDays,
+      sumHours(base.days),
+      base.type as EventType,
+      Number(base.costs) || 0,
+    ),
+  };
   return (
     value && (
       <Formik

--- a/workday-application/src/main/react/features/event/EventForm.tsx
+++ b/workday-application/src/main/react/features/event/EventForm.tsx
@@ -88,6 +88,9 @@ function EventFormFields({ values, setFieldValue }: EventFormFieldsProps) {
             personIds={values.personIds ?? []}
             participants={values.participants ?? []}
             defaultHours={sumHours(values.days)}
+            defaultDays={values.days ?? []}
+            from={values.from}
+            to={values.to}
             total={Number(values.costs) || 0}
             type={values.type}
             knownPersons={values.persons}
@@ -150,6 +153,7 @@ export function EventForm({ value, onSubmit }: EventFormProps) {
       sumHours(base.days),
       base.type as EventType,
       Number(base.costs) || 0,
+      base.days ?? [],
     ),
   };
   return (

--- a/workday-application/src/main/react/features/event/EventForm.tsx
+++ b/workday-application/src/main/react/features/event/EventForm.tsx
@@ -83,20 +83,6 @@ function EventFormFields({ values, setFieldValue }: EventFormFieldsProps) {
         <Grid size={{ xs: 12 }}>
           <PersonSelectorField name="personIds" multiple fullWidth />
         </Grid>
-        <Grid size={{ xs: 12 }}>
-          <EventParticipants
-            personIds={values.personIds ?? []}
-            participants={values.participants ?? []}
-            defaultHours={sumHours(values.days)}
-            defaultDays={values.days ?? []}
-            from={values.from}
-            to={values.to}
-            total={Number(values.costs) || 0}
-            type={values.type}
-            knownPersons={values.persons}
-            setFieldValue={setFieldValue}
-          />
-        </Grid>
         <Grid size={{ xs: 12 }} style={{ marginTop: '1rem' }}>
           <EventTypeSelect
             value={values.type}
@@ -124,6 +110,20 @@ function EventFormFields({ values, setFieldValue }: EventFormFieldsProps) {
             from={values.from}
             to={values.to}
             reset={resetHours}
+          />
+        </Grid>
+        <Grid size={{ xs: 12 }}>
+          <EventParticipants
+            personIds={values.personIds ?? []}
+            participants={values.participants ?? []}
+            defaultHours={sumHours(values.days)}
+            defaultDays={values.days ?? []}
+            from={values.from}
+            to={values.to}
+            total={Number(values.costs) || 0}
+            type={values.type}
+            knownPersons={values.persons}
+            setFieldValue={setFieldValue}
           />
         </Grid>
       </Grid>

--- a/workday-application/src/main/react/features/event/EventForm.tsx
+++ b/workday-application/src/main/react/features/event/EventForm.tsx
@@ -110,6 +110,8 @@ function EventFormFields({ values, setFieldValue }: EventFormFieldsProps) {
             from={values.from}
             to={values.to}
             reset={resetHours}
+            weekLabel
+            hideWeekTotal
           />
         </Grid>
         <Grid size={{ xs: 12 }}>

--- a/workday-application/src/main/react/features/event/EventParticipants.tsx
+++ b/workday-application/src/main/react/features/event/EventParticipants.tsx
@@ -247,24 +247,16 @@ export function EventParticipants({
       return next;
     });
 
-  const setHours = (id: string, raw: string) => {
-    const value = Number(raw);
-    setFieldValue(
-      'participants',
-      participants.map((p) =>
-        p.personId === id
-          ? { ...p, hours: Number.isNaN(value) ? 0 : value, hoursPinned: true }
-          : p,
-      ),
-    );
-  };
-
   const setDay = (id: string, date: Dayjs, hours: number) => {
     setFieldValue(
       'participants',
       participants.map((p) => {
         if (p.personId !== id) return p;
-        const base: Period = { from, to, days: p.days ?? defaultDays };
+        const base: Period = {
+          from,
+          to,
+          days: p.days ?? (multiDay ? defaultDays : [p.hours]),
+        };
         const next = editDay(base, date, hours);
         const days = next.days ?? [];
         return { ...p, days, hours: sum(days), hoursPinned: true };
@@ -336,8 +328,8 @@ export function EventParticipants({
       </Stack>
       <Stack spacing={0.5} sx={{ mt: 1 }}>
         {participants.map((p) => {
-          const effectiveDays = p.days ?? defaultDays;
-          const personHours = multiDay ? sum(effectiveDays) : p.hours;
+          const effectiveDays = p.days ?? (multiDay ? defaultDays : [p.hours]);
+          const personHours = sum(effectiveDays);
           const open = expanded.has(p.personId);
           const overridden =
             !!p.hoursPinned || !!p.costPinned || p.days != null;
@@ -354,6 +346,14 @@ export function EventParticipants({
                   {formatHours(personHours)}
                   {moneyBearing && ` · ${euro(p.cost ?? 0)}`}
                 </Typography>
+                {open && overridden && (
+                  <Button
+                    size="small"
+                    onClick={() => resetParticipant(p.personId)}
+                  >
+                    Reset
+                  </Button>
+                )}
                 <IconButton
                   size="small"
                   onClick={() => toggle(p.personId)}
@@ -363,65 +363,38 @@ export function EventParticipants({
                 </IconButton>
               </Stack>
               <Collapse in={open} unmountOnExit>
-                <Box sx={{ pl: 2, pr: 1, py: 1 }}>
-                  <Stack direction="row" spacing={1} alignItems="center">
-                    {multiDay ? (
-                      <Typography
-                        variant="body2"
-                        color="text.secondary"
-                        sx={{ width: 110 }}
-                      >
-                        {formatHours(personHours)} total
-                      </Typography>
-                    ) : (
-                      <TextField
-                        size="small"
-                        type="number"
-                        label="Hours"
-                        value={p.hours}
-                        onChange={(e) => setHours(p.personId, e.target.value)}
-                        sx={{ width: 110 }}
-                        InputProps={{
-                          endAdornment: (
-                            <InputAdornment position="end">h</InputAdornment>
-                          ),
-                        }}
-                      />
-                    )}
-                    {moneyBearing && (
-                      <TextField
-                        size="small"
-                        type="number"
-                        label="Cost"
-                        value={p.cost ?? 0}
-                        onChange={(e) => setCost(p.personId, e.target.value)}
-                        sx={{ width: 130 }}
-                        InputProps={{
-                          startAdornment: (
-                            <InputAdornment position="start">€</InputAdornment>
-                          ),
-                        }}
-                      />
-                    )}
-                    {overridden && (
-                      <Button
-                        size="small"
-                        onClick={() => resetParticipant(p.personId)}
-                      >
-                        Reset
-                      </Button>
-                    )}
-                  </Stack>
-                  {multiDay && (
-                    <Box sx={{ mt: 1 }}>
-                      <PeriodInput
-                        period={{ from, to, days: effectiveDays }}
-                        onChange={(date, hours) =>
-                          setDay(p.personId, date, hours)
-                        }
-                      />
-                    </Box>
-                  )}
+                <Box sx={{ py: 1 }}>
+                  <PeriodInput
+                    period={{ from, to, days: effectiveDays }}
+                    onChange={(date, hours) => setDay(p.personId, date, hours)}
+                    weekLabel
+                    hideWeekTotal
+                    hidePeriodTotal
+                    trailingHeader={moneyBearing ? 'Cost' : undefined}
+                    renderTrailing={
+                      moneyBearing
+                        ? (weekIndex) =>
+                            weekIndex === 0 ? (
+                              <TextField
+                                size="small"
+                                type="number"
+                                fullWidth
+                                value={p.cost ?? 0}
+                                onChange={(e) =>
+                                  setCost(p.personId, e.target.value)
+                                }
+                                InputProps={{
+                                  startAdornment: (
+                                    <InputAdornment position="start">
+                                      €
+                                    </InputAdornment>
+                                  ),
+                                }}
+                              />
+                            ) : null
+                        : undefined
+                    }
+                  />
                 </Box>
               </Collapse>
             </Box>

--- a/workday-application/src/main/react/features/event/EventParticipants.tsx
+++ b/workday-application/src/main/react/features/event/EventParticipants.tsx
@@ -113,7 +113,9 @@ export function initParticipants(
         costPinned:
           moneyBearing &&
           d.cost != null &&
-          Math.round(d.cost * 100) !== Math.round((shares[i] ?? 0) * 100),
+          Math.abs(
+            Math.round(d.cost * 100) - Math.round((shares[i] ?? 0) * 100),
+          ) > 1,
       };
     });
 }

--- a/workday-application/src/main/react/features/event/EventParticipants.tsx
+++ b/workday-application/src/main/react/features/event/EventParticipants.tsx
@@ -284,10 +284,9 @@ export function EventParticipants({
 
   const setCost = (id: string, raw: string) => {
     const value = Number(raw);
+    const cost = Number.isNaN(value) ? 0 : Math.max(0, value);
     const pinned = participants.map((p) =>
-      p.personId === id
-        ? { ...p, cost: Number.isNaN(value) ? 0 : value, costPinned: true }
-        : p,
+      p.personId === id ? { ...p, cost, costPinned: true } : p,
     );
     setFieldValue('participants', redistribute(pinned, total));
   };

--- a/workday-application/src/main/react/features/event/EventParticipants.tsx
+++ b/workday-application/src/main/react/features/event/EventParticipants.tsx
@@ -1,0 +1,283 @@
+import {
+  Box,
+  Button,
+  InputAdornment,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useEffect, useRef, useState } from 'react';
+import { EventType } from '../../clients/EventClient';
+import { type Person, PersonClient } from '../../clients/PersonClient';
+
+export type Participant = {
+  personId: string;
+  hours: number;
+  cost?: number;
+  hoursPinned?: boolean;
+  costPinned?: boolean;
+};
+
+type EventParticipantsProps = {
+  personIds: string[];
+  participants: Participant[];
+  defaultHours: number;
+  total: number;
+  type: EventType;
+  // Names for attendees that may no longer be active and thus absent from the picker list.
+  knownPersons?: { uuid: string; firstname: string; lastname: string }[];
+  setFieldValue: (field: string, value: unknown) => void;
+};
+
+const euro = (value: number) =>
+  value.toLocaleString('nl-NL', {
+    style: 'currency',
+    currency: 'EUR',
+  });
+
+function splitEvenly(totalEuros: number, count: number): number[] {
+  if (count <= 0) return [];
+  const cents = Math.round(totalEuros * 100);
+  const base = Math.floor(cents / count);
+  const remainder = cents - base * count;
+  return Array.from(
+    { length: count },
+    (_, i) => (base + (i < remainder ? 1 : 0)) / 100,
+  );
+}
+
+function redistribute(rows: Participant[], total: number): Participant[] {
+  const pinnedSum = rows
+    .filter((r) => r.costPinned)
+    .reduce((acc, r) => acc + (r.cost ?? 0), 0);
+  const unpinned = rows.filter((r) => !r.costPinned);
+  const shares = splitEvenly(Math.max(total - pinnedSum, 0), unpinned.length);
+  let i = 0;
+  return rows.map((r) => (r.costPinned ? r : { ...r, cost: shares[i++] ?? 0 }));
+}
+
+export function initParticipants(
+  eventDays: { personId?: string; hours?: number; cost?: number }[] | undefined,
+  defaultHours: number,
+  type: EventType,
+  total: number,
+): Participant[] {
+  if (!eventDays || eventDays.length === 0) return [];
+  const moneyBearing = type !== EventType.FLOCK_HACK_DAY;
+  const shares = splitEvenly(total, eventDays.length);
+  return eventDays
+    .filter((d): d is { personId: string; hours?: number; cost?: number } =>
+      Boolean(d.personId),
+    )
+    .map((d, i) => {
+      const hours = d.hours ?? defaultHours;
+      const cost = moneyBearing ? (d.cost ?? 0) : undefined;
+      return {
+        personId: d.personId,
+        hours,
+        cost,
+        hoursPinned: hours !== defaultHours,
+        costPinned:
+          moneyBearing &&
+          d.cost != null &&
+          Math.round(d.cost * 100) !== Math.round((shares[i] ?? 0) * 100),
+      };
+    });
+}
+
+function reconcile(
+  personIds: string[],
+  current: Participant[],
+  defaultHours: number,
+  total: number,
+  moneyBearing: boolean,
+): Participant[] {
+  const byId = new Map(current.map((p) => [p.personId, p]));
+  const rows: Participant[] = personIds.map((personId) => {
+    const prev = byId.get(personId);
+    return {
+      personId,
+      hoursPinned: prev?.hoursPinned ?? false,
+      hours: prev?.hoursPinned ? prev.hours : defaultHours,
+      costPinned: moneyBearing ? (prev?.costPinned ?? false) : false,
+      cost: moneyBearing
+        ? prev?.costPinned
+          ? prev.cost
+          : undefined
+        : undefined,
+    };
+  });
+  return moneyBearing ? redistribute(rows, total) : rows;
+}
+
+function same(a: Participant[], b: Participant[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every(
+    (p, i) =>
+      p.personId === b[i].personId &&
+      p.hours === b[i].hours &&
+      p.cost === b[i].cost &&
+      !!p.hoursPinned === !!b[i].hoursPinned &&
+      !!p.costPinned === !!b[i].costPinned,
+  );
+}
+
+export function EventParticipants({
+  personIds,
+  participants,
+  defaultHours,
+  total,
+  type,
+  knownPersons = [],
+  setFieldValue,
+}: EventParticipantsProps) {
+  const moneyBearing = type !== EventType.FLOCK_HACK_DAY;
+  const [people, setPeople] =
+    useState<{ uuid: string; firstname: string; lastname: string }[]>(
+      knownPersons,
+    );
+
+  useEffect(() => {
+    PersonClient.queryByPage(
+      { page: 0, size: 200, sort: 'firstname' },
+      { active: true },
+    ).then((res: { list: Person[] }) => {
+      setPeople((prev) => {
+        const merged = new Map(prev.map((p) => [p.uuid, p]));
+        for (const p of res.list) merged.set(p.uuid, p);
+        return [...merged.values()];
+      });
+    });
+  }, []);
+
+  const participantsRef = useRef(participants);
+  participantsRef.current = participants;
+  const personIdsKey = personIds.join(',');
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reconcile reads latest participants via ref; retrigger only on structural inputs
+  useEffect(() => {
+    const current = participantsRef.current;
+    const next = reconcile(
+      personIds,
+      current,
+      defaultHours,
+      total,
+      moneyBearing,
+    );
+    if (!same(next, current)) setFieldValue('participants', next);
+  }, [personIdsKey, defaultHours, total, moneyBearing, setFieldValue]);
+
+  const nameOf = (id: string) => {
+    const p = people.find((it) => it.uuid === id);
+    return p ? `${p.firstname} ${p.lastname}` : id.slice(0, 8);
+  };
+
+  const setHours = (id: string, raw: string) => {
+    const value = Number(raw);
+    setFieldValue(
+      'participants',
+      participants.map((p) =>
+        p.personId === id
+          ? { ...p, hours: Number.isNaN(value) ? 0 : value, hoursPinned: true }
+          : p,
+      ),
+    );
+  };
+
+  const setCost = (id: string, raw: string) => {
+    const value = Number(raw);
+    const pinned = participants.map((p) =>
+      p.personId === id
+        ? { ...p, cost: Number.isNaN(value) ? 0 : value, costPinned: true }
+        : p,
+    );
+    setFieldValue('participants', redistribute(pinned, total));
+  };
+
+  const resetSplit = () => {
+    const shares = splitEvenly(total, participants.length);
+    setFieldValue(
+      'participants',
+      participants.map((p, i) => ({
+        ...p,
+        cost: shares[i] ?? 0,
+        costPinned: false,
+      })),
+    );
+  };
+
+  if (participants.length === 0) return null;
+
+  const costSum = participants.reduce((acc, p) => acc + (p.cost ?? 0), 0);
+  const balanced = Math.round(costSum * 100) === Math.round(total * 100);
+  const anyPinned = participants.some((p) => p.costPinned);
+
+  return (
+    <Box sx={{ mt: 1 }}>
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="baseline"
+      >
+        <Typography variant="subtitle2" color="text.secondary">
+          Per attendee
+        </Typography>
+        {moneyBearing && anyPinned && (
+          <Button size="small" onClick={resetSplit}>
+            Reset to even split
+          </Button>
+        )}
+      </Stack>
+      <Stack spacing={1} sx={{ mt: 1 }}>
+        {participants.map((p) => (
+          <Stack
+            key={p.personId}
+            direction="row"
+            spacing={1}
+            alignItems="center"
+          >
+            <Typography sx={{ flex: 1 }} variant="body2">
+              {nameOf(p.personId)}
+            </Typography>
+            <TextField
+              size="small"
+              type="number"
+              label="Hours"
+              value={p.hours}
+              onChange={(e) => setHours(p.personId, e.target.value)}
+              sx={{ width: 110 }}
+              InputProps={{
+                endAdornment: <InputAdornment position="end">h</InputAdornment>,
+              }}
+            />
+            {moneyBearing && (
+              <TextField
+                size="small"
+                type="number"
+                label="Cost"
+                value={p.cost ?? 0}
+                onChange={(e) => setCost(p.personId, e.target.value)}
+                sx={{ width: 130 }}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">€</InputAdornment>
+                  ),
+                }}
+              />
+            )}
+          </Stack>
+        ))}
+      </Stack>
+      {moneyBearing && (
+        <Typography
+          variant="caption"
+          color={balanced ? 'text.secondary' : 'error'}
+          sx={{ mt: 1, display: 'block', textAlign: 'right' }}
+        >
+          Shares total {euro(costSum)} of {euro(total)}
+          {!balanced && ' — does not match event cost'}
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/workday-application/src/main/react/features/event/EventParticipants.tsx
+++ b/workday-application/src/main/react/features/event/EventParticipants.tsx
@@ -1,5 +1,5 @@
+import AddIcon from '@mui/icons-material/Add';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import {
   Box,
   Button,
@@ -272,14 +272,21 @@ export function EventParticipants({
     );
   };
 
-  const resetDays = (id: string) => {
+  const resetParticipant = (id: string) => {
+    const cleared = participants.map((p) =>
+      p.personId === id
+        ? {
+            ...p,
+            days: undefined,
+            hours: defaultHours,
+            hoursPinned: false,
+            costPinned: false,
+          }
+        : p,
+    );
     setFieldValue(
       'participants',
-      participants.map((p) =>
-        p.personId === id
-          ? { ...p, days: undefined, hours: defaultHours, hoursPinned: false }
-          : p,
-      ),
+      moneyBearing ? redistribute(cleared, total) : cleared,
     );
   };
 
@@ -327,85 +334,96 @@ export function EventParticipants({
           </Button>
         )}
       </Stack>
-      <Stack spacing={1} sx={{ mt: 1 }}>
+      <Stack spacing={0.5} sx={{ mt: 1 }}>
         {participants.map((p) => {
           const effectiveDays = p.days ?? defaultDays;
           const personHours = multiDay ? sum(effectiveDays) : p.hours;
           const open = expanded.has(p.personId);
+          const overridden =
+            !!p.hoursPinned || !!p.costPinned || p.days != null;
           return (
             <Box key={p.personId}>
               <Stack direction="row" spacing={1} alignItems="center">
                 <Typography sx={{ flex: 1 }} variant="body2">
                   {nameOf(p.personId)}
                 </Typography>
-                {multiDay ? (
-                  <Typography
-                    variant="body2"
-                    sx={{ width: 70, textAlign: 'right' }}
-                  >
-                    {formatHours(personHours)}
-                  </Typography>
-                ) : (
-                  <TextField
-                    size="small"
-                    type="number"
-                    label="Hours"
-                    value={p.hours}
-                    onChange={(e) => setHours(p.personId, e.target.value)}
-                    sx={{ width: 110 }}
-                    InputProps={{
-                      endAdornment: (
-                        <InputAdornment position="end">h</InputAdornment>
-                      ),
-                    }}
-                  />
-                )}
-                {moneyBearing && (
-                  <TextField
-                    size="small"
-                    type="number"
-                    label="Cost"
-                    value={p.cost ?? 0}
-                    onChange={(e) => setCost(p.personId, e.target.value)}
-                    sx={{ width: 130 }}
-                    InputProps={{
-                      startAdornment: (
-                        <InputAdornment position="start">€</InputAdornment>
-                      ),
-                    }}
-                  />
-                )}
-                {multiDay && (
-                  <IconButton
-                    size="small"
-                    onClick={() => toggle(p.personId)}
-                    aria-label="hours per day"
-                  >
-                    {open ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-                  </IconButton>
-                )}
+                <Typography
+                  variant="body2"
+                  color={overridden ? 'text.primary' : 'text.secondary'}
+                >
+                  {formatHours(personHours)}
+                  {moneyBearing && ` · ${euro(p.cost ?? 0)}`}
+                </Typography>
+                <IconButton
+                  size="small"
+                  onClick={() => toggle(p.personId)}
+                  aria-label="customize hours and cost"
+                >
+                  {open ? <ExpandLessIcon /> : <AddIcon />}
+                </IconButton>
               </Stack>
-              {multiDay && (
-                <Collapse in={open} unmountOnExit>
-                  <Box sx={{ pl: 2, pr: 1, py: 1 }}>
-                    <PeriodInput
-                      period={{ from, to, days: effectiveDays }}
-                      onChange={(date, hours) =>
-                        setDay(p.personId, date, hours)
-                      }
-                    />
-                    {p.days && (
+              <Collapse in={open} unmountOnExit>
+                <Box sx={{ pl: 2, pr: 1, py: 1 }}>
+                  <Stack direction="row" spacing={1} alignItems="center">
+                    {multiDay ? (
+                      <Typography
+                        variant="body2"
+                        color="text.secondary"
+                        sx={{ width: 110 }}
+                      >
+                        {formatHours(personHours)} total
+                      </Typography>
+                    ) : (
+                      <TextField
+                        size="small"
+                        type="number"
+                        label="Hours"
+                        value={p.hours}
+                        onChange={(e) => setHours(p.personId, e.target.value)}
+                        sx={{ width: 110 }}
+                        InputProps={{
+                          endAdornment: (
+                            <InputAdornment position="end">h</InputAdornment>
+                          ),
+                        }}
+                      />
+                    )}
+                    {moneyBearing && (
+                      <TextField
+                        size="small"
+                        type="number"
+                        label="Cost"
+                        value={p.cost ?? 0}
+                        onChange={(e) => setCost(p.personId, e.target.value)}
+                        sx={{ width: 130 }}
+                        InputProps={{
+                          startAdornment: (
+                            <InputAdornment position="start">€</InputAdornment>
+                          ),
+                        }}
+                      />
+                    )}
+                    {overridden && (
                       <Button
                         size="small"
-                        sx={{ mt: 1 }}
-                        onClick={() => resetDays(p.personId)}
+                        onClick={() => resetParticipant(p.personId)}
                       >
-                        Reset to event days
+                        Reset
                       </Button>
                     )}
-                  </Box>
-                </Collapse>
-              )}
+                  </Stack>
+                  {multiDay && (
+                    <Box sx={{ mt: 1 }}>
+                      <PeriodInput
+                        period={{ from, to, days: effectiveDays }}
+                        onChange={(date, hours) =>
+                          setDay(p.personId, date, hours)
+                        }
+                      />
+                    </Box>
+                  )}
+                </Box>
+              </Collapse>
             </Box>
           );
         })}

--- a/workday-application/src/main/react/features/event/EventParticipants.tsx
+++ b/workday-application/src/main/react/features/event/EventParticipants.tsx
@@ -1,18 +1,27 @@
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import {
   Box,
   Button,
+  Collapse,
+  IconButton,
   InputAdornment,
   Stack,
   TextField,
   Typography,
 } from '@mui/material';
+import type { Dayjs } from 'dayjs';
 import { useEffect, useRef, useState } from 'react';
 import { EventType } from '../../clients/EventClient';
 import { type Person, PersonClient } from '../../clients/PersonClient';
+import { PeriodInput } from '../../components/inputs/PeriodInput';
+import { editDay, type Period } from '../period/Period';
 
 export type Participant = {
   personId: string;
   hours: number;
+  // Per-day hours over the event's date range; undefined means the attendee follows the event blueprint.
+  days?: number[];
   cost?: number;
   hoursPinned?: boolean;
   costPinned?: boolean;
@@ -22,6 +31,9 @@ type EventParticipantsProps = {
   personIds: string[];
   participants: Participant[];
   defaultHours: number;
+  defaultDays: number[];
+  from: Dayjs;
+  to: Dayjs;
   total: number;
   type: EventType;
   // Names for attendees that may no longer be active and thus absent from the picker list.
@@ -34,6 +46,12 @@ const euro = (value: number) =>
     style: 'currency',
     currency: 'EUR',
   });
+
+const sum = (days: number[]) =>
+  days.reduce((acc, h) => acc + (Number(h) || 0), 0);
+
+const formatHours = (hours: number) =>
+  `${hours.toLocaleString('nl-NL', { maximumFractionDigits: 1 })}h`;
 
 function splitEvenly(totalEuros: number, count: number): number[] {
   if (count <= 0) return [];
@@ -57,26 +75,41 @@ function redistribute(rows: Participant[], total: number): Participant[] {
 }
 
 export function initParticipants(
-  eventDays: { personId?: string; hours?: number; cost?: number }[] | undefined,
+  eventDays:
+    | { personId?: string; hours?: number; cost?: number; days?: number[] }[]
+    | undefined,
   defaultHours: number,
   type: EventType,
   total: number,
+  defaultDays: number[],
 ): Participant[] {
   if (!eventDays || eventDays.length === 0) return [];
   const moneyBearing = type !== EventType.FLOCK_HACK_DAY;
+  const multiDay = defaultDays.length > 1;
+  const isOverride = (saved?: number[]) =>
+    multiDay && !!saved && !sameDays(saved, defaultDays);
   const shares = splitEvenly(total, eventDays.length);
   return eventDays
-    .filter((d): d is { personId: string; hours?: number; cost?: number } =>
-      Boolean(d.personId),
+    .filter(
+      (
+        d,
+      ): d is {
+        personId: string;
+        hours?: number;
+        cost?: number;
+        days?: number[];
+      } => Boolean(d.personId),
     )
     .map((d, i) => {
-      const hours = d.hours ?? defaultHours;
+      const days = isOverride(d.days) ? d.days : undefined;
+      const hours = days ? sum(days) : (d.hours ?? defaultHours);
       const cost = moneyBearing ? (d.cost ?? 0) : undefined;
       return {
         personId: d.personId,
         hours,
-        cost,
+        days,
         hoursPinned: hours !== defaultHours,
+        cost,
         costPinned:
           moneyBearing &&
           d.cost != null &&
@@ -89,16 +122,30 @@ function reconcile(
   personIds: string[],
   current: Participant[],
   defaultHours: number,
+  defaultDays: number[],
   total: number,
   moneyBearing: boolean,
 ): Participant[] {
+  const multiDay = defaultDays.length > 1;
   const byId = new Map(current.map((p) => [p.personId, p]));
   const rows: Participant[] = personIds.map((personId) => {
     const prev = byId.get(personId);
+    // Drop a per-person override whose length no longer matches the event range (dates changed).
+    const days =
+      prev?.days && prev.days.length === defaultDays.length
+        ? prev.days
+        : undefined;
+    const hoursPinned = prev?.hoursPinned ?? false;
+    const hours = days
+      ? sum(days)
+      : multiDay || !hoursPinned
+        ? defaultHours
+        : (prev?.hours ?? defaultHours);
     return {
       personId,
-      hoursPinned: prev?.hoursPinned ?? false,
-      hours: prev?.hoursPinned ? prev.hours : defaultHours,
+      days,
+      hoursPinned,
+      hours,
       costPinned: moneyBearing ? (prev?.costPinned ?? false) : false,
       cost: moneyBearing
         ? prev?.costPinned
@@ -110,6 +157,12 @@ function reconcile(
   return moneyBearing ? redistribute(rows, total) : rows;
 }
 
+function sameDays(a: number[] | undefined, b: number[] | undefined): boolean {
+  if (a === b) return true;
+  if (!a || !b) return !a && !b;
+  return a.length === b.length && a.every((v, i) => v === b[i]);
+}
+
 function same(a: Participant[], b: Participant[]): boolean {
   if (a.length !== b.length) return false;
   return a.every(
@@ -118,7 +171,8 @@ function same(a: Participant[], b: Participant[]): boolean {
       p.hours === b[i].hours &&
       p.cost === b[i].cost &&
       !!p.hoursPinned === !!b[i].hoursPinned &&
-      !!p.costPinned === !!b[i].costPinned,
+      !!p.costPinned === !!b[i].costPinned &&
+      sameDays(p.days, b[i].days),
   );
 }
 
@@ -126,16 +180,21 @@ export function EventParticipants({
   personIds,
   participants,
   defaultHours,
+  defaultDays,
+  from,
+  to,
   total,
   type,
   knownPersons = [],
   setFieldValue,
 }: EventParticipantsProps) {
   const moneyBearing = type !== EventType.FLOCK_HACK_DAY;
+  const multiDay = defaultDays.length > 1;
   const [people, setPeople] =
     useState<{ uuid: string; firstname: string; lastname: string }[]>(
       knownPersons,
     );
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     PersonClient.queryByPage(
@@ -161,16 +220,32 @@ export function EventParticipants({
       personIds,
       current,
       defaultHours,
+      defaultDays,
       total,
       moneyBearing,
     );
     if (!same(next, current)) setFieldValue('participants', next);
-  }, [personIdsKey, defaultHours, total, moneyBearing, setFieldValue]);
+  }, [
+    personIdsKey,
+    defaultHours,
+    defaultDays.length,
+    total,
+    moneyBearing,
+    setFieldValue,
+  ]);
 
   const nameOf = (id: string) => {
     const p = people.find((it) => it.uuid === id);
     return p ? `${p.firstname} ${p.lastname}` : id.slice(0, 8);
   };
+
+  const toggle = (id: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
 
   const setHours = (id: string, raw: string) => {
     const value = Number(raw);
@@ -179,6 +254,30 @@ export function EventParticipants({
       participants.map((p) =>
         p.personId === id
           ? { ...p, hours: Number.isNaN(value) ? 0 : value, hoursPinned: true }
+          : p,
+      ),
+    );
+  };
+
+  const setDay = (id: string, date: Dayjs, hours: number) => {
+    setFieldValue(
+      'participants',
+      participants.map((p) => {
+        if (p.personId !== id) return p;
+        const base: Period = { from, to, days: p.days ?? defaultDays };
+        const next = editDay(base, date, hours);
+        const days = next.days ?? [];
+        return { ...p, days, hours: sum(days), hoursPinned: true };
+      }),
+    );
+  };
+
+  const resetDays = (id: string) => {
+    setFieldValue(
+      'participants',
+      participants.map((p) =>
+        p.personId === id
+          ? { ...p, days: undefined, hours: defaultHours, hoursPinned: false }
           : p,
       ),
     );
@@ -229,44 +328,87 @@ export function EventParticipants({
         )}
       </Stack>
       <Stack spacing={1} sx={{ mt: 1 }}>
-        {participants.map((p) => (
-          <Stack
-            key={p.personId}
-            direction="row"
-            spacing={1}
-            alignItems="center"
-          >
-            <Typography sx={{ flex: 1 }} variant="body2">
-              {nameOf(p.personId)}
-            </Typography>
-            <TextField
-              size="small"
-              type="number"
-              label="Hours"
-              value={p.hours}
-              onChange={(e) => setHours(p.personId, e.target.value)}
-              sx={{ width: 110 }}
-              InputProps={{
-                endAdornment: <InputAdornment position="end">h</InputAdornment>,
-              }}
-            />
-            {moneyBearing && (
-              <TextField
-                size="small"
-                type="number"
-                label="Cost"
-                value={p.cost ?? 0}
-                onChange={(e) => setCost(p.personId, e.target.value)}
-                sx={{ width: 130 }}
-                InputProps={{
-                  startAdornment: (
-                    <InputAdornment position="start">€</InputAdornment>
-                  ),
-                }}
-              />
-            )}
-          </Stack>
-        ))}
+        {participants.map((p) => {
+          const effectiveDays = p.days ?? defaultDays;
+          const personHours = multiDay ? sum(effectiveDays) : p.hours;
+          const open = expanded.has(p.personId);
+          return (
+            <Box key={p.personId}>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <Typography sx={{ flex: 1 }} variant="body2">
+                  {nameOf(p.personId)}
+                </Typography>
+                {multiDay ? (
+                  <Typography
+                    variant="body2"
+                    sx={{ width: 70, textAlign: 'right' }}
+                  >
+                    {formatHours(personHours)}
+                  </Typography>
+                ) : (
+                  <TextField
+                    size="small"
+                    type="number"
+                    label="Hours"
+                    value={p.hours}
+                    onChange={(e) => setHours(p.personId, e.target.value)}
+                    sx={{ width: 110 }}
+                    InputProps={{
+                      endAdornment: (
+                        <InputAdornment position="end">h</InputAdornment>
+                      ),
+                    }}
+                  />
+                )}
+                {moneyBearing && (
+                  <TextField
+                    size="small"
+                    type="number"
+                    label="Cost"
+                    value={p.cost ?? 0}
+                    onChange={(e) => setCost(p.personId, e.target.value)}
+                    sx={{ width: 130 }}
+                    InputProps={{
+                      startAdornment: (
+                        <InputAdornment position="start">€</InputAdornment>
+                      ),
+                    }}
+                  />
+                )}
+                {multiDay && (
+                  <IconButton
+                    size="small"
+                    onClick={() => toggle(p.personId)}
+                    aria-label="hours per day"
+                  >
+                    {open ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                  </IconButton>
+                )}
+              </Stack>
+              {multiDay && (
+                <Collapse in={open} unmountOnExit>
+                  <Box sx={{ pl: 2, pr: 1, py: 1 }}>
+                    <PeriodInput
+                      period={{ from, to, days: effectiveDays }}
+                      onChange={(date, hours) =>
+                        setDay(p.personId, date, hours)
+                      }
+                    />
+                    {p.days && (
+                      <Button
+                        size="small"
+                        sx={{ mt: 1 }}
+                        onClick={() => resetDays(p.personId)}
+                      >
+                        Reset to event days
+                      </Button>
+                    )}
+                  </Box>
+                </Collapse>
+              )}
+            </Box>
+          );
+        })}
       </Stack>
       {moneyBearing && (
         <Typography

--- a/workday-application/src/main/react/utils/tests/test-models.tsx
+++ b/workday-application/src/main/react/utils/tests/test-models.tsx
@@ -68,6 +68,7 @@ export function createTestFlockEvent(
     hours: hours,
     days: days,
     persons: [],
+    eventDays: [],
     costs: 0.0,
     type: EventType.GENERAL_EVENT,
   };

--- a/workday-application/src/main/wirespec/budget.ws
+++ b/workday-application/src/main/wirespec/budget.ws
@@ -5,10 +5,19 @@ endpoint BudgetSummary GET /api/budget-summary ? {personId: String?, year: Integ
 type BudgetSummaryResponse {
   hackTimeBudget: BudgetItem,
   trainingTimeBudget: BudgetItem,
-  trainingMoneyBudget: BudgetItem
+  trainingMoneyBudget: BudgetItem,
+  events: BudgetEvent[]
 }
 type BudgetItem {
   budget: Number,
   used: Number,
   available: Number
+}
+type BudgetEvent {
+  eventCode: String,
+  description: String,
+  from: String,
+  hours: Number,
+  cost: Number?,
+  category: String
 }

--- a/workday-application/src/main/wirespec/events.ws
+++ b/workday-application/src/main/wirespec/events.ws
@@ -48,7 +48,8 @@ type Event {
 type EventDay {
   personId: String?,
   hours: Number?,
-  cost: Number?
+  cost: Number?,
+  days: Number[]?
 }
 enum EventType {
   FLOCK_HACK_DAY, FLOCK_COMMUNITY_DAY, CONFERENCE, GENERAL_EVENT
@@ -67,7 +68,8 @@ type EventForm {
 type EventDayForm {
   personId: String?,
   hours: Number?,
-  cost: Number?
+  cost: Number?,
+  days: Number[]?
 }
 enum EventFormType {
   FLOCK_HACK_DAY, FLOCK_COMMUNITY_DAY, CONFERENCE, GENERAL_EVENT

--- a/workday-application/src/main/wirespec/events.ws
+++ b/workday-application/src/main/wirespec/events.ws
@@ -42,7 +42,13 @@ type Event {
   costs: Number?,
   `type`: EventType?,
   days: Number[]?,
-  persons: Person[]?
+  persons: Person[]?,
+  eventDays: EventDay[]?
+}
+type EventDay {
+  personId: String?,
+  hours: Number?,
+  cost: Number?
 }
 enum EventType {
   FLOCK_HACK_DAY, FLOCK_COMMUNITY_DAY, CONFERENCE, GENERAL_EVENT
@@ -55,7 +61,13 @@ type EventForm {
   days: Number[]?,
   costs: Number?,
   personIds: String[]?,
+  participants: EventDayForm[]?,
   `type`: EventFormType?
+}
+type EventDayForm {
+  personId: String?,
+  hours: Number?,
+  cost: Number?
 }
 enum EventFormType {
   FLOCK_HACK_DAY, FLOCK_COMMUNITY_DAY, CONFERENCE, GENERAL_EVENT

--- a/workday-application/src/test/kotlin/community/flock/eco/workday/controllers/EventControllerTest.kt
+++ b/workday-application/src/test/kotlin/community/flock/eco/workday/controllers/EventControllerTest.kt
@@ -416,6 +416,35 @@ class EventControllerTest : WorkdayIntegrationTest() {
     }
 
     @Test
+    fun `explicit participants persist their own per-day hours over a multi-day event`() {
+        val from = LocalDate.of(2023, 3, 1)
+        val to = LocalDate.of(2023, 3, 2)
+        val p1 = createPerson(createUser(userAuthorities).account.user.code)
+        val p2 = createPerson(createUser(userAuthorities).account.user.code)
+        val created =
+            EventForm(
+                description = "Conf",
+                from = from,
+                to = to,
+                hours = 16.0,
+                days = mutableListOf(8.0, 8.0),
+                costs = 0.0,
+                personIds = listOf(p1.uuid, p2.uuid),
+                participants =
+                    listOf(
+                        EventDayInput(p1.uuid, hours = 16.0, cost = null, days = listOf(8.0, 8.0)),
+                        EventDayInput(p2.uuid, hours = 8.0, cost = null, days = listOf(8.0, 0.0)),
+                    ),
+                type = EventType.FLOCK_HACK_DAY,
+            ).run { eventService.create(this) }
+
+        val byPerson = eventDayRepository.findAllByEventCode(created.code).associateBy { it.person.uuid }
+        assertEquals(listOf(8.0, 8.0), byPerson.getValue(p1.uuid).days!!.toList())
+        assertEquals(listOf(8.0, 0.0), byPerson.getValue(p2.uuid).days!!.toList())
+        assertEquals(8.0, byPerson.getValue(p2.uuid).hours)
+    }
+
+    @Test
     fun `hack event participants carry no cost`() {
         val day = LocalDate.of(2023, 3, 1)
         val person = createPerson(createUser(userAuthorities).account.user.code)

--- a/workday-application/src/test/kotlin/community/flock/eco/workday/controllers/EventControllerTest.kt
+++ b/workday-application/src/test/kotlin/community/flock/eco/workday/controllers/EventControllerTest.kt
@@ -1,6 +1,7 @@
 package community.flock.eco.workday.controllers
 
 import community.flock.eco.workday.WorkdayIntegrationTest
+import community.flock.eco.workday.application.forms.EventDayInput
 import community.flock.eco.workday.application.forms.EventForm
 import community.flock.eco.workday.application.forms.PersonForm
 import community.flock.eco.workday.application.model.EventType
@@ -29,6 +30,7 @@ import java.math.BigDecimal
 import java.time.LocalDate
 import java.util.UUID
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class EventControllerTest : WorkdayIntegrationTest() {
     private val baseUrl: String = "/api/events"
@@ -380,6 +382,87 @@ class EventControllerTest : WorkdayIntegrationTest() {
 
         eventService.unsubscribeFromEvent(created.code, p3)
         assertEquals(BigDecimal("1000.00"), costSumOf(created.code))
+    }
+
+    @Test
+    fun `explicit participants persist per-person hours and cost faithfully`() {
+        val day = LocalDate.of(2023, 3, 1)
+        val p1 = createPerson(createUser(userAuthorities).account.user.code)
+        val p2 = createPerson(createUser(userAuthorities).account.user.code)
+        val created =
+            EventForm(
+                description = "Conf",
+                from = day,
+                to = day,
+                hours = 8.0,
+                days = mutableListOf(8.0),
+                costs = 1000.0,
+                personIds = listOf(p1.uuid, p2.uuid),
+                participants =
+                    listOf(
+                        EventDayInput(p1.uuid, hours = 4.0, cost = BigDecimal("600.00")),
+                        EventDayInput(p2.uuid, hours = 12.0, cost = BigDecimal("400.00")),
+                    ),
+                type = EventType.CONFERENCE,
+            ).run { eventService.create(this) }
+
+        val byPerson = eventDayRepository.findAllByEventCode(created.code).associateBy { it.person.uuid }
+        assertEquals(2, byPerson.size)
+        assertEquals(4.0, byPerson.getValue(p1.uuid).hours)
+        assertEquals(12.0, byPerson.getValue(p2.uuid).hours)
+        assertEquals(BigDecimal("600.00"), byPerson.getValue(p1.uuid).cost)
+        assertEquals(BigDecimal("400.00"), byPerson.getValue(p2.uuid).cost)
+        assertEquals(BigDecimal("1000.00"), costSumOf(created.code))
+    }
+
+    @Test
+    fun `hack event participants carry no cost`() {
+        val day = LocalDate.of(2023, 3, 1)
+        val person = createPerson(createUser(userAuthorities).account.user.code)
+        val created =
+            EventForm(
+                description = "Hack",
+                from = day,
+                to = day,
+                hours = 8.0,
+                days = mutableListOf(8.0),
+                costs = 0.0,
+                personIds = listOf(person.uuid),
+                participants = listOf(EventDayInput(person.uuid, hours = 8.0, cost = null)),
+                type = EventType.FLOCK_HACK_DAY,
+            ).run { eventService.create(this) }
+
+        assertNull(eventDayRepository.findAllByEventCode(created.code).single().cost)
+    }
+
+    @Test
+    fun `event response exposes per-person eventDays`() {
+        val day = LocalDate.of(2023, 3, 1)
+        val person = createPerson(createUser(userAuthorities).account.user.code)
+        val created =
+            EventForm(
+                description = "Conf",
+                from = day,
+                to = day,
+                hours = 8.0,
+                days = mutableListOf(8.0),
+                costs = 1000.0,
+                personIds = listOf(person.uuid),
+                participants = listOf(EventDayInput(person.uuid, hours = 5.0, cost = BigDecimal("1000.00"))),
+                type = EventType.CONFERENCE,
+            ).run { eventService.create(this) }
+
+        mvc
+            .perform(
+                get("$baseUrl/${created.code}")
+                    .with(SecurityMockMvcRequestPostProcessors.user(createUser(adminAuthorities)))
+                    .accept(MediaType.APPLICATION_JSON),
+            ).asyncDispatch()
+            .andExpect(status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("\$.eventDays.length()").value(1))
+            .andExpect(MockMvcResultMatchers.jsonPath("\$.eventDays[0].personId").value(person.uuid.toString()))
+            .andExpect(MockMvcResultMatchers.jsonPath("\$.eventDays[0].hours").value(5.0))
+            .andExpect(MockMvcResultMatchers.jsonPath("\$.eventDays[0].cost").value(1000.0))
     }
 
     private fun costSumOf(code: String): BigDecimal =

--- a/workday-application/src/test/kotlin/community/flock/eco/workday/services/BudgetSummaryServiceTest.kt
+++ b/workday-application/src/test/kotlin/community/flock/eco/workday/services/BudgetSummaryServiceTest.kt
@@ -1,6 +1,7 @@
 package community.flock.eco.workday.services
 
 import community.flock.eco.workday.WorkdayIntegrationTest
+import community.flock.eco.workday.application.model.BudgetCategory
 import community.flock.eco.workday.application.model.EventType
 import community.flock.eco.workday.application.repository.EventDayRepository
 import community.flock.eco.workday.application.services.BudgetSummaryService
@@ -66,6 +67,51 @@ class BudgetSummaryServiceTest(
         assertEquals(5000.0, summary.trainingMoneyBudget.budget.toDouble())
         assertEquals(1000.0, summary.trainingMoneyBudget.used.toDouble())
         assertEquals(4000.0, summary.trainingMoneyBudget.available.toDouble())
+    }
+
+    @Test
+    fun `lists a per-event breakdown of the person's budget-bearing event days, sorted by date`() {
+        val person = createHelper.createPersonEntity("Break", "Down")
+        createHelper.createContractInternal(
+            person = person,
+            from = from,
+            to = to,
+            hackTimeBudget = 160,
+            trainingTimeBudget = 200,
+            trainingMoneyBudget = BigDecimal("5000.00"),
+        )
+
+        createHelper.createEvent(
+            from = LocalDate.of(year, 4, 1),
+            to = LocalDate.of(year, 4, 2),
+            hours = 16.0,
+            days = listOf(8.0, 8.0),
+            persons = listOf(person.uuid),
+            costs = 1000.0,
+            type = EventType.CONFERENCE,
+        )
+        createHelper.createEvent(
+            from = LocalDate.of(year, 3, 1),
+            to = LocalDate.of(year, 3, 1),
+            hours = 8.0,
+            days = listOf(8.0),
+            persons = listOf(person.uuid),
+            costs = 0.0,
+            type = EventType.FLOCK_HACK_DAY,
+        )
+
+        val events = budgetSummaryService.getSummary(person.uuid, year).events
+
+        assertEquals(2, events.size)
+
+        val hack = events[0]
+        assertEquals(BudgetCategory.HACK, hack.category)
+        assertEquals(8.0, hack.hours)
+
+        val training = events[1]
+        assertEquals(BudgetCategory.TRAINING, training.category)
+        assertEquals(16.0, training.hours)
+        assertEquals(BigDecimal("1000.00"), training.cost)
     }
 
     @Test


### PR DESCRIPTION
Closes #540.

## What

Three pieces around the per-person `EventDay` breakdown:

**1. Per-attendee hours + cost (event modal).** A row per attendee with their own hours and cost share.

**2. Hours per day on multi-day events.** Each attendee can book their hours per day using the same week-grid the rest of the app uses, so you can tell which day the hours landed on. Single-day events keep the simple total field.

**3. Per-person events on the budget screen.** The `/budget` view lists the events a person attended with their hours and cost, broken down by budget category.

```
Edit Event ────────────────────────────────
 Description [Kotlin Conf            ]
 Costs       [2400                   ]
 Attendees   [Alice][Bob][ + ]
 ─ Per attendee ─────────────────────────────
   Alice   16h   €[1200.00]   ▸  (collapsed)
   Bob     16h   €[1200.00]   ▾
     Week 52   Ma  Di  Wo  Do[8]  Vr[8]  Za  Zo    Total 16
                Shares total €2400 of €2400
```

- **Hours per day:** multi-day events show a collapsible week-grid per attendee. An attendee inherits the event-level day shape until you override it (then a "Reset to event days" link appears). Single-day events keep one Hours field.
- **Cost:** defaults to an even split and is zero-sum (override one share, the others rebalance).
- **Hack events:** hours only, no money column.

## Key decisions

- Per-person `days` persist on `EventDay.days` (the shared `day_days` table), so there is **no migration**.
- A saved `days` array equal to the event blueprint counts as inherited, not an override. Event-day edits then cascade to non-customized attendees, and the reset affordance only shows for genuine overrides.
- Editing stays in the event modal (per-person); the `/budget` screen is the read view.

## Contract changes (`events.ws`, `budget.ws`)

- `Event.eventDays[]` and `EventForm.participants[]` gain `days: Number[]` (per-person hours per day), alongside the existing `personId` / `hours` / `cost`.
- `/api/budget-summary` gains `events[]` (eventCode, description, from, hours, cost, category) for the budget read view.

## Known limitations (carried)

- Self-subscribe re-evens the cost split (no persisted overridden flag); the admin re-adjusts in the modal.
- Cost-share imbalance is warn-only.

## Tests

`EventControllerTest` (explicit participants persist per-person hours, cost, and days; hack rows carry no cost; response exposes eventDays + days), `BudgetSummaryServiceTest` (budget read view). Full backend 222, jest 32, tsc + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
