### PR TITLE
fix: batch day_days fetch to kill home-page N+1

### DIFF
--- a/workday-application/src/main/resources/application.properties
+++ b/workday-application/src/main/resources/application.properties
@@ -14,6 +14,9 @@ spring.session.jdbc.initialize-schema=never
 
 spring.jpa.properties.hibernate.jdbc.time_zone=UTC
 
+# Batches collection/proxy loads into one IN(...) query to kill the Day.days (day_days) N+1.
+spring.jpa.properties.hibernate.default_batch_fetch_size=100
+
 workday.notifications.recipient=workday@flock.community
 
 mailjet.templates.reminderTemplateId=5019452


### PR DESCRIPTION
Closes the home-page slowness (per-person dashboard endpoints were 60-95s).

## Problem
Query insights showed `select d1_0."day_id",d1_0."days" from "day_days" where day_id=$1` called **24,579×** — top query by total load time. `Day.days` is an `@ElementCollection(fetch = EAGER)` on the abstract `Day` base, inherited by WorkDay / EventDay / HolidayDay / SickDay, so Hibernate fires one `day_days` SELECT per Day row (N+1). The FK indexes from #543 made each lookup fast but did nothing about the query *count*; on GCP the `maximum-pool-size=5` pool then serialized them, which is why a trivial PK lookup averaged ~93ms.

## Fix
One property — `spring.jpa.properties.hibernate.default_batch_fetch_size=100` — batches collection/proxy loads into `WHERE id IN (?,?,...)`, collapsing ~24k queries into a few hundred. Also helps `WorkDay.sheets` and `user_authorities`.

## Why not a JOIN FETCH
`days` and `sheets` are both EAGER collections on WorkDay; join-fetching them together is a cartesian product. Batch fetching avoids row multiplication with no query rewrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)