### PR TITLE
fix: soften session-expiry copy

### DIFF
--- a/workday-application/src/main/react/application/ApplicationLayout.tsx
+++ b/workday-application/src/main/react/application/ApplicationLayout.tsx
@@ -161,7 +161,8 @@ export function ApplicationLayout({ onDrawer }: ApplicationLayoutProps) {
             </Button>
           }
         >
-          Extend your session or be redirected you peasant.
+          Quick heads up: your session's almost up. Extend it to stick around,
+          or log back in.
         </Alert>
       </Snackbar>
     </Root>


### PR DESCRIPTION
## What

Replaces the session-expiry snackbar copy in `ApplicationLayout.tsx`.

Before:
> Extend your session or be redirected you peasant.

After:
> Quick heads up: your session's almost up. Extend it to stick around, or log back in.

## Why

Friendlier, less hostile tone while keeping it short and direct.

Note: `PRODUCT.md:17` cites the old "peasant" line as a brand-voice example, so that reference is now stale. Left as-is for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)