### PR TITLE
feat: hackday next-up ordering + dashboard list polish

### DIFF
--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/SickdayController.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/SickdayController.kt
@@ -8,6 +8,7 @@ import community.flock.eco.workday.api.endpoint.PutSickDay
 import community.flock.eco.workday.application.authorities.SickdayAuthority
 import community.flock.eco.workday.application.forms.SickDayForm
 import community.flock.eco.workday.application.interfaces.applyAllowedToUpdate
+import community.flock.eco.workday.application.model.Person
 import community.flock.eco.workday.application.model.SickDay
 import community.flock.eco.workday.application.services.PersonService
 import community.flock.eco.workday.application.services.SickDayService
@@ -125,19 +126,25 @@ class SickdayController(
             ?: throw ResponseStatusException(FORBIDDEN, "User is not linked to person")
     }
 
-    private fun SickDay.externalize(): SickDayApi =
-        SickDayApi(
-            personId = person.uuid.toString(),
+    private fun SickDay.externalize(): SickDayApi {
+        // sick_day columns lack NOT NULL; JPA can hydrate null into these non-null properties.
+        val person: Person? = person
+        val from: LocalDate? = from
+        val to: LocalDate? = to
+        val status: Status? = status
+        return SickDayApi(
+            personId = person?.uuid?.toString(),
             id = id,
             code = code,
-            from = from.toString(),
-            to = to.toString(),
+            from = from?.toString(),
+            to = to?.toString(),
             hours = hours,
             days = days,
             description = description,
-            status = status.toApi(),
+            status = status?.toApi(),
             type = "SickDay",
         )
+    }
 
     private fun Status.toApi(): SickDayStatusApi =
         when (this) {

--- a/workday-application/src/main/react/components/expenses-card/ExpenseTableItem.tsx
+++ b/workday-application/src/main/react/components/expenses-card/ExpenseTableItem.tsx
@@ -1,4 +1,6 @@
-import { TableCell, TableRow } from '@mui/material';
+import DriveEtaIcon from '@mui/icons-material/DriveEta';
+import PaymentsIcon from '@mui/icons-material/Payments';
+import { Box, TableCell, TableRow } from '@mui/material';
 import dayjs from 'dayjs';
 import { DMY_DATE } from '../../clients/util/DateFormats';
 import type { Expense } from '../../wirespec/model';
@@ -10,7 +12,16 @@ type ExpenseTableItemProps = {
 export function ExpenseTableItem({ item }: ExpenseTableItemProps) {
   return (
     <TableRow data-testid={'table-row-expense'}>
-      <TableCell>{item.description}</TableCell>
+      <TableCell>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          {item.expenseType === 'TRAVEL' ? (
+            <DriveEtaIcon fontSize="small" color="action" />
+          ) : (
+            <PaymentsIcon fontSize="small" color="action" />
+          )}
+          <span>{item.description}</span>
+        </Box>
+      </TableCell>
       <TableCell width={120} align={'right'}>
         {dayjs(item.date).format(DMY_DATE)}
       </TableCell>

--- a/workday-application/src/main/react/components/hackday-card/EventListItem.tsx
+++ b/workday-application/src/main/react/components/hackday-card/EventListItem.tsx
@@ -19,8 +19,16 @@ const classes = {
 };
 
 const StyledListItem = styled(ListItem)(({ theme }) => ({
+  border: '1px solid transparent',
+  borderRadius: 6,
+  marginBottom: theme.spacing(1),
+  transition: theme.transitions.create(['background-color', 'border-color']),
+  '&:last-of-type': {
+    marginBottom: 0,
+  },
   [`&.${classes.active}`]: {
-    backgroundColor: alpha(theme.palette.primary.main, 0.14),
+    backgroundColor: alpha(theme.palette.primary.main, 0.12),
+    borderColor: theme.palette.primary.main,
   },
 }));
 

--- a/workday-application/src/main/react/components/hackday-card/HackDayList.tsx
+++ b/workday-application/src/main/react/components/hackday-card/HackDayList.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { FlockEvent } from '../../clients/EventClient';
 import { FlockPagination } from '../pagination/FlockPagination';
 import { EventList } from './EventList';
@@ -15,18 +15,25 @@ type UpcomingEventsCardProps = {
 
 const rowsPerPage = 4;
 
-const getFirstUpcomingEventPage = (items: FlockEvent[]) => {
+const lastPage = (count: number) =>
+  Math.max(0, Math.ceil(count / rowsPerPage) - 1);
+
+const pageOfNextUpcomingEvent = (items: FlockEvent[]) => {
   const today = dayjs();
-  const closestEventIndex = items.findIndex((event) =>
-    event.from.isAfter(today, 'day'),
-  );
-  return closestEventIndex === -1
-    ? 0
-    : Math.floor(closestEventIndex / rowsPerPage);
+  const idx = items.findIndex((event) => !event.from.isBefore(today, 'day'));
+  return idx === -1 ? lastPage(items.length) : Math.floor(idx / rowsPerPage);
 };
 
 export function HackDayList({ items, onEventToggle }: UpcomingEventsCardProps) {
-  const [page, setPage] = useState(getFirstUpcomingEventPage(items));
+  const [page, setPage] = useState(0);
+  const landedOnUpcoming = useRef(false);
+
+  useEffect(() => {
+    if (!landedOnUpcoming.current && items.length > 0) {
+      landedOnUpcoming.current = true;
+      setPage(pageOfNextUpcomingEvent(items));
+    }
+  }, [items]);
 
   return (
     <>

--- a/workday-application/src/main/react/components/missing-hours-card/MissingHoursCard.tsx
+++ b/workday-application/src/main/react/components/missing-hours-card/MissingHoursCard.tsx
@@ -1,7 +1,15 @@
-import { Card, CardContent, CardHeader } from '@mui/material';
-import List from '@mui/material/List';
-import ListItemButton from '@mui/material/ListItemButton';
-import ListItemText from '@mui/material/ListItemText';
+import ScheduleRoundedIcon from '@mui/icons-material/ScheduleRounded';
+import {
+  Box,
+  Card,
+  CardContent,
+  CardHeader,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+} from '@mui/material';
 import Typography from '@mui/material/Typography';
 import { AlignedLoader } from '@workday-core/components/AlignedLoader';
 import { useEffect, useState } from 'react';
@@ -79,21 +87,29 @@ export function MissingHoursCard({ totalPerPersonMe }: MissingHoursCardProps) {
   };
 
   function renderItem(item: AggregationPersonObject, index: number) {
+    const monthLabel = new Date(item.monthYear).toLocaleString('en-EN', {
+      month: 'long',
+      year: 'numeric',
+    });
+    const hours = Math.round(item.missing);
     return (
-      <ListItemButton
+      <TableRow
+        hover
         key={index}
         onClick={() => openWorkDayDialog(item)}
-        sx={{ borderRadius: 2, py: 0.75 }}
+        sx={{ cursor: 'pointer' }}
+        data-testid={'table-row-missing-hours'}
       >
-        <ListItemText
-          primary={`You have missing hours in
-                    ${new Date(item.monthYear).toLocaleString('en-EN', {
-                      month: 'long',
-                    })}`}
-          primaryTypographyProps={{ fontSize: 14 }}
-          sx={{ my: 0 }}
-        />
-      </ListItemButton>
+        <TableCell>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <ScheduleRoundedIcon fontSize="small" color="action" />
+            <span>{monthLabel}</span>
+          </Box>
+        </TableCell>
+        <TableCell width={110} align={'right'}>
+          {hours} h
+        </TableCell>
+      </TableRow>
     );
   }
 
@@ -107,9 +123,15 @@ export function MissingHoursCard({ totalPerPersonMe }: MissingHoursCardProps) {
       )}
       {data.length > 0 && (
         <CardContent>
-          <List disablePadding>
-            {data.map((it, idx) => renderItem(it, idx))}
-          </List>
+          <Table size={'small'}>
+            <TableHead>
+              <TableRow>
+                <TableCell>Month</TableCell>
+                <TableCell align={'right'}>Missing</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>{data.map((it, idx) => renderItem(it, idx))}</TableBody>
+          </Table>
         </CardContent>
       )}
       <MissingHoursDetailDialog


### PR DESCRIPTION

<img width="1334" height="738" alt="Scherm­afbeelding 2026-06-30 om 10 41 03" src="https://github.com/user-attachments/assets/756d59d3-a021-4dc8-95c4-b3fbf17826f1" />

## What

The home dashboard's **"Hack days of this year"** card now opens on the page holding the **next upcoming hackday**, instead of January's past events.

## Why it was broken

The starting page was computed in a `useState` initializer, which runs once on mount — before the parent's async event fetch resolves. With an empty list it always returned page 1, so the page-jump never actually happened (the original `getFirstUpcomingEventPage` had the same latent flaw).

## Fix

- Compute the target page in a `useEffect` that fires once events arrive (guarded by a ref so later refetches — e.g. after toggling attendance — don't yank you off your current page).
- Land on the page with the first event **on or after today** (today included, via `!from.isBefore(today, 'day')`); if every event is in the past, open on the **last** page so the most recent hackday is visible.
- List order stays natural chronological (past → future), as returned by the backend.

## Verified

Ran this branch's frontend locally against seeded data (20 hackdays across 2026, today = Jun 30). Card opens on **page 4**, showing `14-07-2026` onward — the first hackdays after today — confirmed via the live DOM.

## Note

The widget is still capped to the current calendar year (`/api/events/year`, filtered on `from` only). So "next upcoming" can't see into next year — a late-December next hackday in January won't appear until the year rolls over. Out of scope here; flag if a rolling window is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)