### PR TITLE
feat: polish dashboard list widgets

### DIFF
--- a/workday-application/src/main/react/components/expenses-card/ExpenseTableItem.tsx
+++ b/workday-application/src/main/react/components/expenses-card/ExpenseTableItem.tsx
@@ -1,4 +1,6 @@
-import { TableCell, TableRow } from '@mui/material';
+import DriveEtaIcon from '@mui/icons-material/DriveEta';
+import PaymentsIcon from '@mui/icons-material/Payments';
+import { Box, TableCell, TableRow } from '@mui/material';
 import dayjs from 'dayjs';
 import { DMY_DATE } from '../../clients/util/DateFormats';
 import type { Expense } from '../../wirespec/model';
@@ -10,7 +12,16 @@ type ExpenseTableItemProps = {
 export function ExpenseTableItem({ item }: ExpenseTableItemProps) {
   return (
     <TableRow data-testid={'table-row-expense'}>
-      <TableCell>{item.description}</TableCell>
+      <TableCell>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          {item.expenseType === 'TRAVEL' ? (
+            <DriveEtaIcon fontSize="small" color="action" />
+          ) : (
+            <PaymentsIcon fontSize="small" color="action" />
+          )}
+          <span>{item.description}</span>
+        </Box>
+      </TableCell>
       <TableCell width={120} align={'right'}>
         {dayjs(item.date).format(DMY_DATE)}
       </TableCell>

--- a/workday-application/src/main/react/components/hackday-card/EventListItem.tsx
+++ b/workday-application/src/main/react/components/hackday-card/EventListItem.tsx
@@ -19,8 +19,16 @@ const classes = {
 };
 
 const StyledListItem = styled(ListItem)(({ theme }) => ({
+  border: '1px solid transparent',
+  borderRadius: 6,
+  marginBottom: theme.spacing(1),
+  transition: theme.transitions.create(['background-color', 'border-color']),
+  '&:last-of-type': {
+    marginBottom: 0,
+  },
   [`&.${classes.active}`]: {
-    backgroundColor: alpha(theme.palette.primary.main, 0.14),
+    backgroundColor: alpha(theme.palette.primary.main, 0.12),
+    borderColor: theme.palette.primary.main,
   },
 }));
 

--- a/workday-application/src/main/react/components/missing-hours-card/MissingHoursCard.tsx
+++ b/workday-application/src/main/react/components/missing-hours-card/MissingHoursCard.tsx
@@ -1,7 +1,15 @@
-import { Card, CardContent, CardHeader } from '@mui/material';
-import List from '@mui/material/List';
-import ListItemButton from '@mui/material/ListItemButton';
-import ListItemText from '@mui/material/ListItemText';
+import {
+  Box,
+  Card,
+  CardContent,
+  CardHeader,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+} from '@mui/material';
+import ScheduleRoundedIcon from '@mui/icons-material/ScheduleRounded';
 import Typography from '@mui/material/Typography';
 import { AlignedLoader } from '@workday-core/components/AlignedLoader';
 import { useEffect, useState } from 'react';
@@ -79,26 +87,34 @@ export function MissingHoursCard({ totalPerPersonMe }: MissingHoursCardProps) {
   };
 
   function renderItem(item: AggregationPersonObject, index: number) {
+    const monthLabel = new Date(item.monthYear).toLocaleString('en-EN', {
+      month: 'long',
+      year: 'numeric',
+    });
+    const hours = Math.round(item.missing);
     return (
-      <ListItemButton
+      <TableRow
+        hover
         key={index}
         onClick={() => openWorkDayDialog(item)}
-        sx={{ borderRadius: 2, py: 0.75 }}
+        sx={{ cursor: 'pointer' }}
+        data-testid={'table-row-missing-hours'}
       >
-        <ListItemText
-          primary={`You have missing hours in
-                    ${new Date(item.monthYear).toLocaleString('en-EN', {
-                      month: 'long',
-                    })}`}
-          primaryTypographyProps={{ fontSize: 14 }}
-          sx={{ my: 0 }}
-        />
-      </ListItemButton>
+        <TableCell>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <ScheduleRoundedIcon fontSize="small" color="action" />
+            <span>{monthLabel}</span>
+          </Box>
+        </TableCell>
+        <TableCell width={110} align={'right'}>
+          {hours} h
+        </TableCell>
+      </TableRow>
     );
   }
 
   return (
-    <Card variant={'outlined'} sx={{ borderRadius: '14px' }}>
+    <Card variant={'outlined'} style={{ borderRadius: 0 }}>
       <CardHeader title={'Missing hours'} />
       {data.length === 0 && (
         <CardContent>
@@ -107,9 +123,17 @@ export function MissingHoursCard({ totalPerPersonMe }: MissingHoursCardProps) {
       )}
       {data.length > 0 && (
         <CardContent>
-          <List disablePadding>
-            {data.map((it, idx) => renderItem(it, idx))}
-          </List>
+          <Table size={'small'}>
+            <TableHead>
+              <TableRow>
+                <TableCell>Month</TableCell>
+                <TableCell align={'right'}>Missing</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {data.map((it, idx) => renderItem(it, idx))}
+            </TableBody>
+          </Table>
         </CardContent>
       )}
       <MissingHoursDetailDialog


### PR DESCRIPTION
Polishes three home-dashboard list widgets for visual consistency. Pure UI; no behavior or data changes.

## Hack days
Attending rows now read as distinct outlined chips instead of merging into one yellow block:
- 1px border + soft yellow wash (`primary` @ 0.12) on active rows, transparent border otherwise (no layout shift on toggle)
- 6px radius, 8px row gap

The active edge follows the theme — black in light mode, brand yellow in dark — matching the native Flock app's event-row treatment.

## Missing hours
Reworked from a plain bullet list of repeated "You have missing hours in June" sentences into a compact table that matches the **expenses-table idiom**:
- `<Table size="small">` with **Month / Missing** columns
- Muted clock icon (`color="action"`) inline with the month
- Surfaces the missing-hours **count** per row (e.g. "23 h"), which was computed but previously hidden
- Hover + click still opens the detail dialog

## Expenses widget
Each row gains its **type icon** — `DriveEta` for travel, `Payments` for cost (`color="action"`) — mirroring the full expenses page so the widget and the page match.

## Verification
Ran the frontend locally against seeded data and confirmed via the live DOM: active hackday rows carry the yellow border + wash; missing-hours renders as a Month/Missing table with clock icons and counts; expense rows show the correct travel/cost icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)