### PR TITLE
test: dedupe managerEmployeeFlow pagination walk to fix e2e flake

### DIFF
--- a/tests/managerEmployeeFlow.spec.ts
+++ b/tests/managerEmployeeFlow.spec.ts
@@ -1,4 +1,5 @@
 import { expect, type Locator, type Page, test } from '@playwright/test';
+import { findOnAnyPage } from './steps/dayListSteps';
 import {
   Given_I_am_logged_in_as_user,
   When_I_fill_in_the_date_range_from_till,
@@ -55,38 +56,6 @@ async function changeStatusOnLocator(
   await page.getByRole('menuitem', { name: toStatus }).click();
   await page.waitForLoadState('networkidle');
   await expect(locator.getByRole('button', { name: toStatus })).toBeVisible();
-}
-
-// Walk the FlockPagination ("Go to next page") until `locator` resolves.
-// Both the SickDay and LeaveDay APIs sit on top of Spring's standard
-// Pageable resolver, which sets the `x-total` response header that the
-// frontend uses to compute the page count. The WorkDay API does the same
-// via its Page<T>.toResponse() helper. Seeded mock data spreads dozens of
-// entries across years for ernie, so our run-specific entry can sit
-// several pages deep.
-async function findOnAnyPage(
-  page: Page,
-  locator: Locator,
-  maxPages = 25,
-): Promise<Locator> {
-  for (let i = 0; i < maxPages; i++) {
-    if ((await locator.count()) > 0) {
-      return locator.first();
-    }
-    const nextBtn = page.getByRole('button', { name: 'Go to next page' });
-    if (
-      (await nextBtn.count()) === 0 ||
-      !(await nextBtn.isVisible()) ||
-      !(await nextBtn.isEnabled())
-    ) {
-      throw new Error(
-        `findOnAnyPage: could not find locator within ${maxPages} pages`,
-      );
-    }
-    await nextBtn.click();
-    await page.waitForLoadState('networkidle');
-  }
-  throw new Error('findOnAnyPage: exceeded the page-walk safety limit');
 }
 
 test.describe


### PR DESCRIPTION
## What

Deletes the stale private `findOnAnyPage` in `tests/managerEmployeeFlow.spec.ts` and imports the hardened shared one from `tests/steps/dayListSteps.ts`. Net −31 lines.

## Why

CI run [#28434026849](https://github.com/flock-community/flock-eco-workday/actions/runs/28434026849) flaked: only **e2e shard 2/3** failed, on Bert's leave-day approval, with `findOnAnyPage: could not find locator within 25 pages`. It failed all 3 attempts in that run (Playwright re-runs the whole `.serial` chain on retry) and then **passed cleanly on a re-run of the same shard with no code change** — the signature of a render race, not a real regression.

Root cause is duplication. `managerEmployeeFlow` carried an old copy of the helper that read `locator.count()` the instant after navigation:

- `page.waitForLoadState('networkidle')` settles when the fetch completes, **not** when React has painted the table rows.
- The walk saw 0 rows on the target's page and advanced past it (or, on a single-page list where the pager is hidden, threw immediately) — with zero retry tolerance.

The shared `findOnAnyPage` in `steps/dayListSteps.ts` already fixed exactly this by `expect.poll()`-ing for the row or pager to render before checking `count()`. Every spec using it (events, budget, leaveday, workdayAdmin = shards 1 & 3) passed. This change routes the manager flow's 6 call sites through that same proven helper.

## Notes for reviewer

- No production code touched — test-only.
- `Locator` / `Page` type imports stay (still used by the local `selectErnieFromPersonSelector` / `changeStatusOnLocator` helpers).
- Typechecks clean; `playwright test --list` still discovers all 4 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)