### PR TITLE
feat: de-emphasize out-of-range days in PeriodInput grid (#547)

### DIFF
--- a/workday-application/src/main/react/components/inputs/PeriodInput.tsx
+++ b/workday-application/src/main/react/components/inputs/PeriodInput.tsx
@@ -77,7 +77,7 @@ function DayField({
   const field = (
     <TextField
       size="small"
-      label={day.disabled ? '-' : day.date.format('DD MMM')}
+      label={day.disabled ? '' : day.date.format('DD MMM')}
       value={day.value}
       disabled={day.disabled}
       onChange={(ev) => onChange(day.date, parseFloat(ev.target.value || '0'))}
@@ -87,6 +87,7 @@ function DayField({
         background
           ? { '& .MuiOutlinedInput-root': { backgroundColor: background } }
           : false,
+        day.disabled ? { opacity: 0.4 } : false,
       ]}
       fullWidth={fullWidth}
     />


### PR DESCRIPTION
Closes #547.

## What

The shared per-day week grid (`PeriodInput`) rendered out-of-range days as full-border disabled inputs labelled `-`. On a short multi-day event most of the Ma–Zo row is out of range, so the editor showed mostly noise (a 2-day event = 5 greyed `-` cells, 2 real ones).

This fades those cells (`opacity: 0.4`) and drops the `-` placeholder so the eye lands on the days that are actually editable.

```diff
-      label={day.disabled ? '-' : day.date.format('DD MMM')}
+      label={day.disabled ? '' : day.date.format('DD MMM')}
       ...
+        day.disabled ? { opacity: 0.4 } : false,
```

## Decisions

- **Option 1 from the issue (fade app-wide), the lowest-risk option.** The change lives entirely in `DayField`, so it covers both render paths (the labelled event/week-label grid and WorkDay's month grid) with one edit.
- **Alignment preserved.** The 7-column grid template is untouched, so out-of-range cells keep their column under the correct `Ma/Di/Wo/...` header — you still read which weekdays the range spans, they just recede. WorkDay's month grid and the leave/sick forms get the same mild weekend de-emphasis.
- Kept MUI's default disabled hairline border (an earlier draft also softened the border, which pushed the cells close to invisible — that read as "hide", not "fade").

## Verification

- `tsc --noEmit`: 0 errors. `biome check`: clean (no new warnings/errors).
- No DOM/label change to *enabled* cells and no structural change, so the Playwright e2e selectors (events/leaveday/sickday/workdayAdmin) are unaffected; disabled cells were never interacted with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)