### PR TITLE
feat: sunglasses dark-mode toggle icon

### DIFF
--- a/workday-application/src/main/react/theme/ColorModeToggle.tsx
+++ b/workday-application/src/main/react/theme/ColorModeToggle.tsx
@@ -1,8 +1,8 @@
-import DarkModeIcon from '@mui/icons-material/Bedtime';
 import LightModeIcon from '@mui/icons-material/LightMode';
 import IconButton, { type IconButtonProps } from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import { useColorMode } from './ColorMode';
+import { SunglassesIcon } from './SunglassesIcon';
 
 export function ColorModeToggle(props: IconButtonProps) {
   const { mode, toggle } = useColorMode();
@@ -16,7 +16,7 @@ export function ColorModeToggle(props: IconButtonProps) {
         aria-label={`Switch to ${next} mode`}
         {...props}
       >
-        {mode === 'light' ? <DarkModeIcon /> : <LightModeIcon />}
+        {mode === 'light' ? <SunglassesIcon /> : <LightModeIcon />}
       </IconButton>
     </Tooltip>
   );

--- a/workday-application/src/main/react/theme/SunglassesIcon.tsx
+++ b/workday-application/src/main/react/theme/SunglassesIcon.tsx
@@ -1,11 +1,12 @@
 import SvgIcon, { type SvgIconProps } from '@mui/material/SvgIcon';
 
 // Replaces the conventional moon on the dark-mode toggle: a nod to the
-// shades-wearing flock on flock.community.
+// shades-wearing flock on flock.community. Browline bar with deep rounded
+// lenses, sized to match the optical weight of the Material icons beside it.
 export function SunglassesIcon(props: SvgIconProps) {
   return (
     <SvgIcon {...props}>
-      <path d="M 1.9 8.5 C 6 7.95 9.5 8.7 12 9.7 C 14.5 8.7 18 7.95 22.1 8.5 C 22.5 8.6 22.6 8.9 22.5 9.4 C 22.2 12.4 21.6 14.2 20.4 15.0 C 19.6 15.5 18.0 15.7 16.6 15.6 C 15.2 15.5 14.4 15.1 14.0 13.9 C 13.6 12.6 13.2 11.3 12.6 10.6 C 12.4 10.4 11.6 10.4 11.4 10.6 C 10.8 11.3 10.4 12.6 10.0 13.9 C 9.6 15.1 8.8 15.5 7.4 15.6 C 6.0 15.7 4.4 15.5 3.6 15.0 C 2.4 14.2 1.8 12.4 1.5 9.4 C 1.4 8.9 1.5 8.6 1.9 8.5 Z" />
+      <path d="M3 7h18a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2Zm0 2h7.25v5a2.5 2.5 0 0 1-2.5 2.5H5.5A2.5 2.5 0 0 1 3 14Zm10.75 0H21v5a2.5 2.5 0 0 1-2.5 2.5h-2.25a2.5 2.5 0 0 1-2.5-2.5Z" />
     </SvgIcon>
   );
 }

--- a/workday-application/src/main/react/theme/SunglassesIcon.tsx
+++ b/workday-application/src/main/react/theme/SunglassesIcon.tsx
@@ -1,12 +1,12 @@
 import SvgIcon, { type SvgIconProps } from '@mui/material/SvgIcon';
 
 // Replaces the conventional moon on the dark-mode toggle: a nod to the
-// shades-wearing flock on flock.community. Wayfarer silhouette with a flat
-// brow line and tapered lenses, so it reads as sunglasses even at 24px.
+// shades-wearing flock on flock.community. Wayfarer silhouette traced from
+// the brand reference artwork and fitted to the 24px Material icon grid.
 export function SunglassesIcon(props: SvgIconProps) {
   return (
     <SvgIcon {...props}>
-      <path d="M2.1 7.9H10.4C10.9 7.9 11.2 9.2 12 9.2C12.8 9.2 13.1 7.9 13.6 7.9H21.9C21.8 10.3 21.4 13.4 20.9 14.4C20.45 15.3 19.6 15.68 18.5 15.7L15.6 15.7C14.55 15.66 14.05 15.25 13.8 14.4L12.7 10.6C12.5 10.15 11.5 10.15 11.3 10.6L10.2 14.4C9.95 15.25 9.45 15.66 8.4 15.7L5.5 15.7C4.4 15.68 3.55 15.3 3.1 14.4C2.6 13.4 2.2 10.3 2.1 7.9Z" />
+      <path d="M4.49 9.03C3.79 9.07 2.88 9.15 2.53 9.20C2.04 9.27 2.00 9.33 2.00 9.93L2.00 10.36 2.36 10.71L2.72 11.07 3.01 12.23C3.57 14.50 3.84 14.76 5.82 14.94C8.01 15.13 9.49 14.76 10.10 13.86C10.36 13.47 10.74 12.59 11.05 11.65C11.23 11.10 11.28 11.07 11.93 11.07C12.52 11.07 12.60 11.12 12.75 11.54C13.55 13.88 13.93 14.40 15.06 14.75C16.23 15.11 19.10 14.99 19.74 14.56C20.22 14.24 20.51 13.63 20.78 12.42C21.07 11.13 21.24 10.77 21.68 10.55C21.90 10.43 22.00 9.83 21.86 9.43C21.81 9.27 21.80 9.26 21.43 9.21C19.25 8.87 15.49 8.99 13.30 9.47C12.62 9.62 11.73 9.69 11.36 9.63C11.23 9.60 10.80 9.52 10.41 9.44C8.89 9.12 6.13 8.93 4.49 9.03" />
     </SvgIcon>
   );
 }

--- a/workday-application/src/main/react/theme/SunglassesIcon.tsx
+++ b/workday-application/src/main/react/theme/SunglassesIcon.tsx
@@ -1,12 +1,17 @@
 import SvgIcon, { type SvgIconProps } from '@mui/material/SvgIcon';
 
 // Replaces the conventional moon on the dark-mode toggle: a nod to the
-// shades-wearing flock on flock.community. Wayfarer silhouette traced from
-// the brand reference artwork and fitted to the 24px Material icon grid.
+// shades-wearing flock on flock.community. The wayfarer silhouette, traced
+// from the brand reference artwork, is knocked out of a filled disc so the
+// icon matches the weight of the Material icons beside it — the disc
+// treatment also echoes the Flock logo.
 export function SunglassesIcon(props: SvgIconProps) {
   return (
     <SvgIcon {...props}>
-      <path d="M4.49 9.03C3.79 9.07 2.88 9.15 2.53 9.20C2.04 9.27 2.00 9.33 2.00 9.93L2.00 10.36 2.36 10.71L2.72 11.07 3.01 12.23C3.57 14.50 3.84 14.76 5.82 14.94C8.01 15.13 9.49 14.76 10.10 13.86C10.36 13.47 10.74 12.59 11.05 11.65C11.23 11.10 11.28 11.07 11.93 11.07C12.52 11.07 12.60 11.12 12.75 11.54C13.55 13.88 13.93 14.40 15.06 14.75C16.23 15.11 19.10 14.99 19.74 14.56C20.22 14.24 20.51 13.63 20.78 12.42C21.07 11.13 21.24 10.77 21.68 10.55C21.90 10.43 22.00 9.83 21.86 9.43C21.81 9.27 21.80 9.26 21.43 9.21C19.25 8.87 15.49 8.99 13.30 9.47C12.62 9.62 11.73 9.69 11.36 9.63C11.23 9.60 10.80 9.52 10.41 9.44C8.89 9.12 6.13 8.93 4.49 9.03" />
+      <path
+        fillRule="evenodd"
+        d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20ZM5.39 9.39C4.78 9.42 3.97 9.49 3.67 9.54C3.24 9.60 3.20 9.65 3.20 10.18L3.20 10.56 3.52 10.86L3.83 11.18 4.09 12.20C4.58 14.20 4.82 14.43 6.56 14.59C8.49 14.75 9.79 14.43 10.33 13.64C10.56 13.29 10.89 12.52 11.16 11.69C11.32 11.21 11.37 11.18 11.94 11.18C12.46 11.18 12.53 11.23 12.66 11.60C13.36 13.65 13.70 14.11 14.69 14.42C15.72 14.74 18.25 14.63 18.81 14.25C19.23 13.97 19.49 13.43 19.73 12.37C19.98 11.23 20.13 10.92 20.52 10.72C20.71 10.62 20.80 10.09 20.68 9.74C20.63 9.60 20.62 9.59 20.30 9.54C18.38 9.25 15.07 9.35 13.14 9.77C12.55 9.91 11.76 9.97 11.44 9.91C11.32 9.89 10.94 9.82 10.60 9.75C9.26 9.47 6.83 9.30 5.39 9.39Z"
+      />
     </SvgIcon>
   );
 }

--- a/workday-application/src/main/react/theme/SunglassesIcon.tsx
+++ b/workday-application/src/main/react/theme/SunglassesIcon.tsx
@@ -1,0 +1,11 @@
+import SvgIcon, { type SvgIconProps } from '@mui/material/SvgIcon';
+
+// Replaces the conventional moon on the dark-mode toggle: a nod to the
+// shades-wearing flock on flock.community.
+export function SunglassesIcon(props: SvgIconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path d="M 1.9 8.5 C 6 7.95 9.5 8.7 12 9.7 C 14.5 8.7 18 7.95 22.1 8.5 C 22.5 8.6 22.6 8.9 22.5 9.4 C 22.2 12.4 21.6 14.2 20.4 15.0 C 19.6 15.5 18.0 15.7 16.6 15.6 C 15.2 15.5 14.4 15.1 14.0 13.9 C 13.6 12.6 13.2 11.3 12.6 10.6 C 12.4 10.4 11.6 10.4 11.4 10.6 C 10.8 11.3 10.4 12.6 10.0 13.9 C 9.6 15.1 8.8 15.5 7.4 15.6 C 6.0 15.7 4.4 15.5 3.6 15.0 C 2.4 14.2 1.8 12.4 1.5 9.4 C 1.4 8.9 1.5 8.6 1.9 8.5 Z" />
+    </SvgIcon>
+  );
+}

--- a/workday-application/src/main/react/theme/SunglassesIcon.tsx
+++ b/workday-application/src/main/react/theme/SunglassesIcon.tsx
@@ -1,16 +1,12 @@
 import SvgIcon, { type SvgIconProps } from '@mui/material/SvgIcon';
 
 // Replaces the conventional moon on the dark-mode toggle: a nod to the
-// shades-wearing flock on flock.community. The wayfarer silhouette is knocked
-// out of a filled disc so the icon carries the same weight as the Material
-// icons beside it — the disc treatment also echoes the Flock logo.
+// shades-wearing flock on flock.community. Wayfarer silhouette with a flat
+// brow line and tapered lenses, so it reads as sunglasses even at 24px.
 export function SunglassesIcon(props: SvgIconProps) {
   return (
     <SvgIcon {...props}>
-      <path
-        fillRule="evenodd"
-        d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20ZM4.73 9.62c2.95-.39 5.47.15 7.27.87 1.8-.72 4.32-1.26 7.27-.87.29.08.36.29.29.65-.22 2.16-.65 3.46-1.51 4.03-.58.36-1.73.51-2.74.44-1.01-.08-1.58-.36-1.87-1.23-.29-.93-.58-1.87-1.01-2.37-.14-.15-.72-.15-.86 0-.43.5-.72 1.44-1.01 2.37-.29.87-.86 1.15-1.87 1.23-1.01.07-2.16-.08-2.74-.44-.86-.57-1.29-1.87-1.51-4.03-.07-.36 0-.57.29-.65Z"
-      />
+      <path d="M2.1 7.9H10.4C10.9 7.9 11.2 9.2 12 9.2C12.8 9.2 13.1 7.9 13.6 7.9H21.9C21.8 10.3 21.4 13.4 20.9 14.4C20.45 15.3 19.6 15.68 18.5 15.7L15.6 15.7C14.55 15.66 14.05 15.25 13.8 14.4L12.7 10.6C12.5 10.15 11.5 10.15 11.3 10.6L10.2 14.4C9.95 15.25 9.45 15.66 8.4 15.7L5.5 15.7C4.4 15.68 3.55 15.3 3.1 14.4C2.6 13.4 2.2 10.3 2.1 7.9Z" />
     </SvgIcon>
   );
 }

--- a/workday-application/src/main/react/theme/SunglassesIcon.tsx
+++ b/workday-application/src/main/react/theme/SunglassesIcon.tsx
@@ -1,12 +1,16 @@
 import SvgIcon, { type SvgIconProps } from '@mui/material/SvgIcon';
 
 // Replaces the conventional moon on the dark-mode toggle: a nod to the
-// shades-wearing flock on flock.community. Browline bar with deep rounded
-// lenses, sized to match the optical weight of the Material icons beside it.
+// shades-wearing flock on flock.community. The wayfarer silhouette is knocked
+// out of a filled disc so the icon carries the same weight as the Material
+// icons beside it — the disc treatment also echoes the Flock logo.
 export function SunglassesIcon(props: SvgIconProps) {
   return (
     <SvgIcon {...props}>
-      <path d="M3 7h18a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2Zm0 2h7.25v5a2.5 2.5 0 0 1-2.5 2.5H5.5A2.5 2.5 0 0 1 3 14Zm10.75 0H21v5a2.5 2.5 0 0 1-2.5 2.5h-2.25a2.5 2.5 0 0 1-2.5-2.5Z" />
+      <path
+        fillRule="evenodd"
+        d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20ZM4.73 9.62c2.95-.39 5.47.15 7.27.87 1.8-.72 4.32-1.26 7.27-.87.29.08.36.29.29.65-.22 2.16-.65 3.46-1.51 4.03-.58.36-1.73.51-2.74.44-1.01-.08-1.58-.36-1.87-1.23-.29-.93-.58-1.87-1.01-2.37-.14-.15-.72-.15-.86 0-.43.5-.72 1.44-1.01 2.37-.29.87-.86 1.15-1.87 1.23-1.01.07-2.16-.08-2.74-.44-.86-.57-1.29-1.87-1.51-4.03-.07-.36 0-.57.29-.65Z"
+      />
     </SvgIcon>
   );
 }


### PR DESCRIPTION

<img width="1079" height="601" alt="afbeelding" src="https://github.com/user-attachments/assets/291957e9-afbb-47a5-b549-0d5aba5b104a" />


## What

Replaces the moon (`@mui/icons-material/Bedtime`) on the color-mode toggle with a custom wayfarer-sunglasses `SvgIcon`, a nod to the shades-wearing flock on flock.community. It shows in the light→dark direction; the sun stays for dark→light.

## Decisions

- New `theme/SunglassesIcon.tsx` is a plain `SvgIcon`: `currentColor` fill and the default 24px size, so it themes and scales exactly like the moon it replaces (ink on the yellow top bar in light mode, cream in dark). No colors hardcoded.
- Solid silhouette, no lens glints, for a crisp read at 24px.
- No API/contract changes. The icon swap automatically reaches both spots that use `ColorModeToggle`: the top app bar and the login screen (top-right).

## Verification

Local: `biome check` clean, `tsc --noEmit` green, app boots and the toggle flips light↔dark correctly. Shape reviewed against the flock.community brand reference in-session.
