### PR TITLE
fix: stop duplicate OAuth couplings from 500ing authenticated requests

### DIFF
--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/config/KratosIdentityUserResolver.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/config/KratosIdentityUserResolver.kt
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Conditional
 import org.springframework.context.annotation.Configuration
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.HttpStatus
 import org.springframework.http.client.SimpleClientHttpRequestFactory
 import org.springframework.http.converter.HttpMessageConversionException
@@ -72,6 +73,10 @@ class KratosIdentityUserResolver(
             throw HydraUserinfoUnavailableException("Hydra /userinfo returned an unparseable response", ex)
         }
 
+    // Both catches re-read the winner of a find-or-create race. The DataIntegrityViolationException one
+    // depends on resolve() running outside a transaction: this @Transactional create must be the outermost
+    // tx so the unique-constraint violation flushes at its own commit and is caught here. An enclosing tx
+    // would defer the throw past these catches and 500 the request.
     private fun findOrCreateAccount(
         sub: String,
         email: String,
@@ -88,7 +93,8 @@ class KratosIdentityUserResolver(
                     ),
                 ).user
         } catch (ex: UserAccountExistsException) {
-            // A concurrent request created the account first; re-read instead of failing.
+            findExistingUserBySub(sub) ?: throw ex
+        } catch (ex: DataIntegrityViolationException) {
             findExistingUserBySub(sub) ?: throw ex
         }
 }

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/PersonController.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/PersonController.kt
@@ -193,12 +193,11 @@ class PersonController(
 
     private fun User.externalize(): UserApi {
         val created: LocalDateTime? = created
-        val authorities: Set<String>? = authorities
         return UserApi(
             id = code,
             name = name,
             email = email,
-            authorities = authorities?.toList(),
+            authorities = authorities.toList(),
             accounts = null,
             created = created?.toString(),
         )

--- a/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/PersonController.kt
+++ b/workday-application/src/main/kotlin/community/flock/eco/workday/application/controllers/PersonController.kt
@@ -24,6 +24,7 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.util.UUID
 import community.flock.eco.workday.api.model.Person as PersonApi
 import community.flock.eco.workday.api.model.PersonEvent as PersonEventApi
@@ -163,10 +164,14 @@ class PersonController(
                 }
             }
 
-    private fun Person.externalize(): PersonApi =
-        PersonApi(
+    private fun Person.externalize(): PersonApi {
+        // person/user columns lack NOT NULL; JPA can hydrate null into these non-null properties.
+        val uuid: UUID? = uuid
+        val firstname: String? = firstname
+        val lastname: String? = lastname
+        return PersonApi(
             id = id,
-            uuid = uuid.toString(),
+            uuid = uuid?.toString(),
             firstname = firstname,
             lastname = lastname,
             email = email,
@@ -182,18 +187,22 @@ class PersonController(
             shirtSize = shirtSize,
             googleDriveId = googleDriveId,
             user = user?.externalize(),
-            fullName = "$firstname $lastname",
+            fullName = listOfNotNull(firstname, lastname).joinToString(" ").ifBlank { null },
         )
+    }
 
-    private fun User.externalize(): UserApi =
-        UserApi(
+    private fun User.externalize(): UserApi {
+        val created: LocalDateTime? = created
+        val authorities: Set<String>? = authorities
+        return UserApi(
             id = code,
             name = name,
             email = email,
-            authorities = authorities.toList(),
+            authorities = authorities?.toList(),
             accounts = null,
-            created = created.toString(),
+            created = created?.toString(),
         )
+    }
 
     private fun PersonEvent.externalize(): PersonEventApi =
         PersonEventApi(

--- a/workday-application/src/test/kotlin/community/flock/eco/workday/application/config/KratosIdentityUserResolverTest.kt
+++ b/workday-application/src/test/kotlin/community/flock/eco/workday/application/config/KratosIdentityUserResolverTest.kt
@@ -14,6 +14,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -131,6 +132,19 @@ class KratosIdentityUserResolverTest {
         val resolved = resolver.resolve("sub-race", "token-race")
 
         assertThat(resolved.email).isEqualTo("race@flock.community")
+    }
+
+    @Test
+    fun `a unique-constraint race loser re-reads the account by reference instead of failing`() {
+        val user = userWithEmail("constraint@flock.community")
+        every { userAccountService.findUserAccountOauthByReference("sub-constraint") } returnsMany
+            listOf(null, oauth(user, "sub-constraint"))
+        every { userAccountService.createUserAccountOauth(any()) } throws DataIntegrityViolationException("uc_user_account_oauth_provider_reference")
+        expectUserinfo("token-constraint", withSuccess(userinfoBody("constraint@flock.community"), MediaType.APPLICATION_JSON))
+
+        val resolved = resolver.resolve("sub-constraint", "token-constraint")
+
+        assertThat(resolved.email).isEqualTo("constraint@flock.community")
     }
 
     private fun expectUserinfo(

--- a/workday-user/src/main/database/flock-eco-feature-user-002-oauth-unique-reference.yaml
+++ b/workday-user/src/main/database/flock-eco-feature-user-002-oauth-unique-reference.yaml
@@ -1,0 +1,27 @@
+databaseChangeLog:
+  - changeSet:
+      id: flock-eco-feature-user-002-oauth-unique-reference-1
+      author: rkorver
+      comment: >-
+        Make (provider, reference) unique on user_account_oauth so a find-or-create
+        race can no longer mint duplicate OAuth couplings (which broke
+        findByReference and 500'd every authenticated request). DESTRUCTIVE: first
+        deduplicates existing rows, keeping the oldest (min id) per
+        (provider, reference). NULL provider/reference tuples are left untouched —
+        they never violate a unique constraint under Postgres NULL semantics.
+      changes:
+        - sql:
+            sql: >-
+              DELETE FROM user_account_oauth
+              WHERE provider IS NOT NULL
+                AND reference IS NOT NULL
+                AND id NOT IN (
+                  SELECT MIN(id)
+                  FROM user_account_oauth
+                  WHERE provider IS NOT NULL AND reference IS NOT NULL
+                  GROUP BY provider, reference
+                );
+        - addUniqueConstraint:
+            tableName: user_account_oauth
+            columnNames: provider, reference
+            constraintName: uc_user_account_oauth_provider_reference

--- a/workday-user/src/main/database/flock-eco-feature-user-master.yaml
+++ b/workday-user/src/main/database/flock-eco-feature-user-master.yaml
@@ -2,3 +2,6 @@ databaseChangeLog:
   - include:
     - file: flock-eco-feature-user-001-init.yaml
       relativeToChangelogFile: true
+  - include:
+    - file: flock-eco-feature-user-002-oauth-unique-reference.yaml
+      relativeToChangelogFile: true

--- a/workday-user/src/main/kotlin/community/flock/eco/workday/user/model/UserAccountOauth.kt
+++ b/workday-user/src/main/kotlin/community/flock/eco/workday/user/model/UserAccountOauth.kt
@@ -3,9 +3,19 @@ package community.flock.eco.workday.user.model
 import community.flock.eco.workday.core.events.EventEntityListeners
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
 
 @Entity
 @EntityListeners(EventEntityListeners::class)
+@Table(
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uc_user_account_oauth_provider_reference",
+            columnNames = ["provider", "reference"],
+        ),
+    ],
+)
 class UserAccountOauth(
     id: Long = 0,
     user: User,

--- a/workday-user/src/test/kotlin/community/flock/eco/workday/user/repositories/UserAccountOauthRepositoryTest.kt
+++ b/workday-user/src/test/kotlin/community/flock/eco/workday/user/repositories/UserAccountOauthRepositoryTest.kt
@@ -1,0 +1,37 @@
+package community.flock.eco.workday.user.repositories
+
+import community.flock.eco.workday.user.UserConfiguration
+import community.flock.eco.workday.user.model.User
+import community.flock.eco.workday.user.model.UserAccountOauth
+import community.flock.eco.workday.user.model.UserAccountOauthProvider
+import jakarta.transaction.Transactional
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.dao.DataIntegrityViolationException
+
+@SpringBootTest(classes = [UserConfiguration::class])
+@AutoConfigureTestDatabase
+@AutoConfigureDataJpa
+@Transactional
+class UserAccountOauthRepositoryTest(
+    @Autowired private val userRepository: UserRepository,
+    @Autowired private val userAccountOauthRepository: UserAccountOauthRepository,
+) {
+    @Test
+    fun `a second coupling with the same provider and reference is rejected`() {
+        val user = userRepository.save(User(name = "Sjors", email = "sjors@flock.community"))
+        userAccountOauthRepository.saveAndFlush(
+            UserAccountOauth(user = user, reference = "sub-sjors", provider = UserAccountOauthProvider.KRATOS),
+        )
+
+        assertThatExceptionOfType(DataIntegrityViolationException::class.java).isThrownBy {
+            userAccountOauthRepository.saveAndFlush(
+                UserAccountOauth(user = user, reference = "sub-sjors", provider = UserAccountOauthProvider.KRATOS),
+            )
+        }
+    }
+}


### PR DESCRIPTION
## What & why

A TestFlight user got locked out: authenticated requests started 500ing and the failing endpoint drifted (`/api/sickdays` → `/api/persons/me` → `/api/workdays`). The real fault is upstream of all of them.

`KratosIdentityUserResolver.resolve(sub)` does a find-or-create on the user's OAuth coupling. The mobile client fires concurrent authenticated requests at startup (e.g. `persons.me()` from both `HomeFeed.load()` and `HomeFeed.loadGlances()`), and for a brand-new user **all** of them see zero couplings, so they **all** create one. `UserAccountService.createUserAccountOauth` guards by email, not by `reference(sub)`, and there is no DB constraint — so the race mints multiple `UserAccountOauth(KRATOS)` rows with the same `reference`.

Once more than one exists, the single-result `findByReference` throws `IncorrectResultSizeDataAccessException`, unhandled → **HTTP 500 on every authenticated endpoint** that re-reads the coupling.

```mermaid
sequenceDiagram
  participant A as request A
  participant B as request B
  participant DB
  A->>DB: findByReference(sub) → none
  B->>DB: findByReference(sub) → none
  A->>DB: INSERT oauth(KRATOS, sub)
  B->>DB: INSERT oauth(KRATOS, sub)
  Note over DB: two rows, same reference
  A->>DB: findByReference(sub) → 2 rows → 500
```

## The fix

1. **Unique `(provider, reference)` constraint** on `user_account_oauth` — declared on both the JPA entity (`@UniqueConstraint`, so it exists in the Hibernate-generated test/dev schema) and Liquibase (prod), mirroring how `User` declares its constraints. This is the real guarantee: a check-then-act guard can't close a race; only the DB can serialize concurrent inserts.
2. **Resolver idempotency** — `findOrCreateAccount` now catches the constraint race-loser (`DataIntegrityViolationException`) and re-reads the winner, alongside the existing `UserAccountExistsException` path. Kept localized to the Kratos path; the shared `createUserAccountOauth` contract is untouched (GOOGLE login uses it too). A comment pins the one invariant the recovery depends on: `resolve()` must run outside a transaction, or the violation defers past the catch.
3. **Defensive null-guards** on `/api/persons/me` serialisation (folded in from #560), so a malformed person/user row degrades instead of 500ing.

## ⚠️ Destructive migration — gate the deploy

Liquibase `flock-eco-feature-user-002-oauth-unique-reference` **deletes duplicate `user_account_oauth` rows in prod** (keeps `min(id)` per `(provider, reference)`) before adding the constraint — required, or the constraint add fails on the existing duplicates. NULL provider/reference tuples are left untouched (they never violate under Postgres NULL semantics). Code is safe to merge; please coordinate the actual deploy (Roman / Willem) since it mutates prod data once.

## Tests

- DB-layer repository test: a duplicate `(provider, reference)` save is rejected by the constraint.
- Resolver test: the constraint race-loser re-reads the winner instead of 500ing.
- Full suite green (245 tests, `en_US` locale to dodge the known nl_NL email-test flake).

Supersedes #560 — its null-guard commits are included here. Related: #555 (sickday null-guard, already deployed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
