### PR TITLE
fix: patch js-yaml to 3.15.0 to clear Dependabot security alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5765,9 +5765,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,10 @@
     "vite": "^8.0.16"
   },
   "overrides": {
-    "react-is": "^19.0.0"
+    "react-is": "^19.0.0",
+    "@istanbuljs/load-nyc-config": {
+      "js-yaml": "^3.15.0"
+    }
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,css}": [


### PR DESCRIPTION
## Problem

The **Dependabot Updates** workflow keeps failing on the js-yaml security job with `security_update_not_possible`:

> A patched version exists for js-yaml, but the available update path would downgrade jest from 30.4.2 to 25.0.0

`js-yaml` is a **transitive, dev-only** dependency pulled in solely by `@istanbuljs/load-nyc-config` (`^3.13.1`, jest/istanbul coverage tooling). That package is unmaintained and always pins the v3 line, so Dependabot can't bump js-yaml without a parent bump it's unable to make — and the committed lockfile stayed on the vulnerable `3.14.2` (Dependabot alert #264).

## Fix

Scoped npm `override` forcing the patched `js-yaml@^3.15.0` only within `@istanbuljs/load-nyc-config`:

```json
"overrides": {
  "@istanbuljs/load-nyc-config": {
    "js-yaml": "^3.15.0"
  }
}
```

- `3.15.0` is the patched v3 release — same major, API-compatible (`safeLoad` etc. intact), so no risk to the istanbul/jest path. (v4 would have broken it.)
- Scoped rather than blanket so a future js-yaml 4.x consumer wouldn't get force-downgraded.
- js-yaml is `dev: true` — never shipped to production.
- `npm audit` now reports **0 vulnerabilities**.

Diff is just the override block plus the lockfile bump `3.14.2 → 3.15.0`.

## Note on the other red Dependabot jobs

minimatch, brace-expansion, @babel/core and handlebars also show historical failures, but their committed lockfile versions are **already patched** (`3.1.5`, `1.1.15`/`2.1.1`, `7.29.7`, `4.7.9` — handlebars even logs *"no longer vulnerable"*). Those alerts self-resolve on Dependabot's next re-evaluation; js-yaml was the only one still on a vulnerable version.

Supersedes the duplicate PR #562 (identical fix from an earlier session) and the stuck Dependabot PR #424.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SwaTVBaxB9Udq1X2KatFir)_