### PR TITLE
fix: purge orphaned user_account rows that 500 authenticated reads

### DIFF
--- a/workday-user/src/main/database/flock-eco-feature-user-003-purge-orphan-user-accounts.yaml
+++ b/workday-user/src/main/database/flock-eco-feature-user-003-purge-orphan-user-accounts.yaml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+  - changeSet:
+      id: flock-eco-feature-user-003-purge-orphan-user-accounts-1
+      author: rkorver
+      comment: >-
+        Repair for flock-eco-feature-user-002. That changeset deduped by deleting
+        rows from the user_account_oauth subclass table but left their user_account
+        base rows behind. UserAccount is JOINED-inheritance with no discriminator,
+        so an orphan base row (no row in oauth/password/key) has no resolvable
+        concrete type: when Hibernate batch-loads the EAGER, polymorphic
+        User.accounts collection it builds an EntityKey with a null persister and
+        NPEs — 500ing every authenticated read that touches such a user. Delete the
+        orphaned base rows. DESTRUCTIVE, but an orphan carries no oauth/password/key
+        data, so it is already dead as an entity.
+      changes:
+        - sql:
+            sql: >-
+              DELETE FROM user_account
+              WHERE NOT EXISTS (SELECT 1 FROM user_account_oauth o WHERE o.id = user_account.id)
+                AND NOT EXISTS (SELECT 1 FROM user_account_password p WHERE p.id = user_account.id)
+                AND NOT EXISTS (SELECT 1 FROM user_account_key k WHERE k.id = user_account.id)

--- a/workday-user/src/main/database/flock-eco-feature-user-master.yaml
+++ b/workday-user/src/main/database/flock-eco-feature-user-master.yaml
@@ -5,3 +5,6 @@ databaseChangeLog:
   - include:
     - file: flock-eco-feature-user-002-oauth-unique-reference.yaml
       relativeToChangelogFile: true
+  - include:
+    - file: flock-eco-feature-user-003-purge-orphan-user-accounts.yaml
+      relativeToChangelogFile: true

--- a/workday-user/src/test/kotlin/community/flock/eco/workday/user/repositories/UserAccountOrphanPurgeTest.kt
+++ b/workday-user/src/test/kotlin/community/flock/eco/workday/user/repositories/UserAccountOrphanPurgeTest.kt
@@ -1,0 +1,87 @@
+package community.flock.eco.workday.user.repositories
+
+import community.flock.eco.workday.user.UserConfiguration
+import community.flock.eco.workday.user.model.User
+import community.flock.eco.workday.user.model.UserAccountOauth
+import community.flock.eco.workday.user.model.UserAccountOauthProvider
+import jakarta.persistence.EntityManager
+import jakarta.transaction.Transactional
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest(classes = [UserConfiguration::class])
+@AutoConfigureTestDatabase
+@AutoConfigureDataJpa
+@Transactional
+class UserAccountOrphanPurgeTest(
+    @Autowired private val userRepository: UserRepository,
+    @Autowired private val userAccountOauthRepository: UserAccountOauthRepository,
+    @Autowired private val entityManager: EntityManager,
+) {
+    // Logically identical to flock-eco-feature-user-003-purge-orphan-user-accounts.yaml; identifiers are
+    // quoted here only because the Hibernate-created test schema stores them case-sensitively under
+    // globally_quoted_identifiers (the migration runs unquoted, like changeset 002, against Postgres).
+    private val purgeOrphans =
+        """
+        DELETE FROM "user_account"
+        WHERE NOT EXISTS (SELECT 1 FROM "user_account_oauth" o WHERE o."id" = "user_account"."id")
+          AND NOT EXISTS (SELECT 1 FROM "user_account_password" p WHERE p."id" = "user_account"."id")
+          AND NOT EXISTS (SELECT 1 FROM "user_account_key" k WHERE k."id" = "user_account"."id")
+        """.trimIndent()
+
+    @Test
+    fun `an orphaned user_account base row 500s every read of the owning user`() {
+        val user = orphanedAccountOwner()
+
+        // User.accounts is an EAGER, JOINED-polymorphic @OneToMany: loading the user force-initialises it,
+        // and the orphan base row has no subclass row, so Hibernate cannot resolve a concrete persister.
+        assertThatThrownBy { userRepository.findById(user.id).orElseThrow().accounts.size }
+            .isInstanceOf(RuntimeException::class.java)
+    }
+
+    @Test
+    fun `purging the orphaned base row restores polymorphic account loading`() {
+        val user = orphanedAccountOwner()
+
+        entityManager.createNativeQuery(purgeOrphans).executeUpdate()
+        entityManager.flush()
+        entityManager.clear()
+
+        val reloaded = userRepository.findById(user.id).orElseThrow()
+        assertThat(reloaded.accounts).hasSize(1) // the surviving (non-orphaned) coupling
+        val orphanRows =
+            entityManager
+                .createNativeQuery("""SELECT count(*) FROM "user_account" WHERE "id" = :id""")
+                .setParameter("id", orphanId)
+                .singleResult as Number
+        assertThat(orphanRows.toInt()).isZero()
+    }
+
+    private var orphanId: Long = 0
+
+    // Seeds a user with one valid KRATOS coupling and one coupling we orphan exactly the way
+    // flock-eco-feature-user-002 did: delete the user_account_oauth subclass row, keep its user_account base row.
+    private fun orphanedAccountOwner(): User {
+        val user = userRepository.save(User(name = "Pim", email = "pim@flock.community"))
+        userAccountOauthRepository.saveAndFlush(
+            UserAccountOauth(user = user, reference = "keep", provider = UserAccountOauthProvider.KRATOS),
+        )
+        val orphan =
+            userAccountOauthRepository.saveAndFlush(
+                UserAccountOauth(user = user, reference = "stray", provider = UserAccountOauthProvider.GOOGLE),
+            )
+        orphanId = orphan.id
+        entityManager
+            .createNativeQuery("""DELETE FROM "user_account_oauth" WHERE "id" = :id""")
+            .setParameter("id", orphan.id)
+            .executeUpdate()
+        entityManager.flush()
+        entityManager.clear()
+        return user
+    }
+}


### PR DESCRIPTION
## Symptom

Since the #561 deploy, authenticated reads across the dashboard return **HTTP 500**, with a *drifting* set of failing endpoints (`/api/aggregations/*-me`, `events`, `persons/me`, …). Production logs show the same exception every time:

```
java.lang.NullPointerException: Cannot invoke "EntityPersister.getRootEntityName()" because "this.persister" is null
  at org.hibernate.engine.spi.EntityKey.generateHashCode(EntityKey.java:61)
  ...
  at ...CollectionBatchLoaderArrayParam.initializeKeys
  at ...StatefulPersistenceContext.initializeNonLazyCollections
  at EventService.findAll(EventService.kt:35)   // and findAllEventsOf(EventService.kt:40)
```

## Root cause

`UserAccount` is `@Inheritance(JOINED)` with **no JPA discriminator**; its three subclass tables (`user_account_oauth` / `_password` / `_key`) each FK their `id` back to `user_account.id`.

PR #561's changeset `002` deduped couplings with `DELETE FROM user_account_oauth …` — that removed the **subclass** rows but left their **`user_account` base rows orphaned**. An orphan base row has no row in any subclass table, so Hibernate cannot resolve a concrete type for it. When it batch-loads the **EAGER, polymorphic `User.accounts`** collection it builds an `EntityKey` with a `null` persister and NPEs.

`User.accounts` is reached on most authenticated reads through the eager closure:

```
Event → eventDays (EAGER, @BatchSize) → EventDay → person (EAGER) → Person → user (EAGER) → User → accounts (EAGER, polymorphic)
```

so *any* request that loads an affected user 500s — which is why the failing endpoint drifts rather than staying fixed. This is the actual cause of the post-#561 500s (not the `findByReference` grain question raised in the handoff — that throws `IncorrectResultSizeDataAccessException`, which appears in none of the traces).

## Fix

One Liquibase changeset (`003`) that deletes the orphaned base rows — the single point every failing read routes through, so it fixes them all at once without touching application code:

```sql
DELETE FROM user_account
WHERE NOT EXISTS (SELECT 1 FROM user_account_oauth    o WHERE o.id = user_account.id)
  AND NOT EXISTS (SELECT 1 FROM user_account_password p WHERE p.id = user_account.id)
  AND NOT EXISTS (SELECT 1 FROM user_account_key      k WHERE k.id = user_account.id)
```

An orphan carries no oauth/password/key data, so it is already dead as an entity — deleting it is non‑destructive in practice. Deliberately **not** done: making `User.accounts` lazy (wider blast radius, `open-in-view=false`) or adding a discriminator column (large migration) — neither is needed once the dead rows are gone, and there is no ongoing source of new orphans (only #561's one-time raw delete created them).

## Deploy notes

- **DESTRUCTIVE migration that runs at boot** — gate the production deploy exactly like #561's `002`.
- Per the handoff: an older `main` run (#557, without #561) was still pending production approval. Don't approve it after this — it would deploy an image without changeset `002`/`003`.

## Tests

`UserAccountOrphanPurgeTest` (DB‑layer, H2):
- reproduces the orphan exactly as #561's delete created it and confirms loading the owning user **throws** (the production NPE);
- confirms changeset `003`'s SQL **removes the orphan and restores** polymorphic `User.accounts` loading, keeping the valid coupling.

Full reactor `./mvnw -B -T 1C package` is green (incl. `EventController`/`AggregationService`/`KratosIdentityUserResolver` suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZ5sqF2NWepbasx1MJKGbd)_