### PR TITLE
style: remove hand-drawn marker highlight from home greeting

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -85,6 +85,6 @@ No layout-property animation, no bounce. Respect `prefers-reduced-motion`.
 
 ## Signature
 
-The hand-drawn marker highlight (`HighlightSpan` + the `#markerShape` SVG turbulence
-filter in `index.html`) is the brand's human touch. Kept and reusable beyond the home
-greeting.
+The hand-drawn marker highlight was retired; the home greeting is a plain heading.
+The brand's human touch now rests on the cheeky copy and on yellow used with intent
+(AppBar, primary actions, selection states).

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -8,7 +8,7 @@ perceptual consistency and emitted as hex/rgb so MUI's colour manipulators
 ## Color
 
 Strategy: **committed**. The Flock yellow carries real surface presence (app bar,
-primary actions, the marker highlight) against warm, low-chroma neutrals. Neutrals
+primary actions) against warm, low-chroma neutrals. Neutrals
 are tinted toward the yellow hue (~100) so nothing is a dead grey, and pure
 `#000`/`#fff` are never used.
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -14,7 +14,7 @@ Flock Workday is a standalone workforce-management application: time tracking, l
 
 ## Brand Personality
 
-Flock. Confident, warm, a little playful. Three words: bold, friendly, precise. The signature is the bright Flock yellow (#fcde00) used with conviction, paired with a hand-drawn marker-highlight motif that gives an otherwise utilitarian tool a human, crafted touch. Voice is direct and lightly irreverent (the existing session-expiry copy calls the user a "peasant"), never corporate-bland.
+Flock. Confident, warm, a little playful. Three words: bold, friendly, precise. The signature is the bright Flock yellow (#fcde00) used with conviction, giving an otherwise utilitarian tool a human, crafted touch. Voice is direct and lightly irreverent (the existing session-expiry copy calls the user a "peasant"), never corporate-bland.
 
 ## Anti-references
 
@@ -26,7 +26,7 @@ Flock. Confident, warm, a little playful. Three words: bold, friendly, precise. 
 
 - **Yellow with intent.** The Flock yellow is the brand and stays prominent, but it signals (brand surfaces, primary action, highlight) rather than smothering. Every yellow placement is a deliberate choice, not a fill-by-default.
 - **Calm density.** Data-entry and review screens reward fast scanning: clear hierarchy, generous-but-consistent rhythm, quiet neutrals so the yellow and the data stand out.
-- **Crafted, not corporate.** Keep the human touches (the marker highlight, the cheeky copy). The tool should feel made by people who care.
+- **Crafted, not corporate.** Keep the human touches (the cheeky copy). The tool should feel made by people who care.
 - **One coherent system.** Colour, type, spacing, elevation and components come from shared tokens so every screen inherits the polish, including future ones.
 - **Light and dark, both first-class.** Neutrals are tinted toward the brand hue; the yellow reads well on warm off-white and warm near-black alike.
 

--- a/workday-application/src/main/react/features/home/HomeFeature.tsx
+++ b/workday-application/src/main/react/features/home/HomeFeature.tsx
@@ -27,7 +27,6 @@ import { addError } from '../../hooks/ErrorHook';
 import { usePerson } from '../../hooks/PersonHook';
 import { useLoginStatus } from '../../hooks/StatusHook';
 import { useUserMe } from '../../hooks/UserMeHook';
-import { HighlightSpan } from '../../theme/theme-light';
 import type { Expense } from '../../wirespec/model/Expense';
 import { ExpenseDialog } from '../expense/ExpenseDialog';
 import { LeaveDayDialog } from '../holiday/LeaveDayDialog';
@@ -119,9 +118,7 @@ export function HomeFeature() {
             gap: '12px',
           }}
         >
-          <Typography variant="h2">
-            Hi, <HighlightSpan>{user?.name}!</HighlightSpan>
-          </Typography>
+          <Typography variant="h2">Hi, {user?.name}!</Typography>
           {hasAccess && (
             <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
               <Button

--- a/workday-application/src/main/react/index.html
+++ b/workday-application/src/main/react/index.html
@@ -115,29 +115,5 @@
   <body>
     <main id="index" class="content-grid"></main>
     <script type="module" src="./index.jsx"></script>
-    <svg
-      xmlns="//www.w3.org/2000/svg"
-      version="1.1"
-      class="svg-filters"
-      style="display: none"
-    >
-      <defs>
-        <filter id="markerShape">
-          <feTurbulence
-            type="fractalNoise"
-            baseFrequency="0 0.15"
-            numOctaves="1"
-            result="warp"
-          />
-          <feDisplacementMap
-            xChannelSelector="R"
-            yChannelSelector="G"
-            scale="30"
-            in="SourceGraphic"
-            in2="warp"
-          />
-        </filter>
-      </defs>
-    </svg>
   </body>
 </html>

--- a/workday-application/src/main/react/theme/theme-light.ts
+++ b/workday-application/src/main/react/theme/theme-light.ts
@@ -1,22 +1,3 @@
-import { styled } from '@mui/material/styles';
 import { createAppTheme } from './createAppTheme';
 
 export const themeLight = createAppTheme('light');
-
-export const HighlightSpan = styled('span')(({ theme }) => ({
-  position: 'relative',
-  fontFamily: theme.typography.fontFamily,
-  color: theme.palette.primary.contrastText,
-  '&::before': {
-    content: '""',
-    backgroundColor: theme.palette.primary.main,
-    width: '100%',
-    height: '.9em',
-    position: 'absolute',
-    zIndex: '-1',
-    filter: 'url(#markerShape)',
-    left: '-0.15em',
-    top: '0.1em',
-    padding: '0 0.15em',
-  },
-}));


### PR DESCRIPTION
## What

Removes the hand-drawn marker highlight from the home greeting ("Hi, *{name}*!"), which is now a plain `h2` heading. Chosen from five mocked-up alternatives (option 1: remove it altogether).

## Changes

- **`HomeFeature.tsx`** — greeting renders as plain `<Typography variant="h2">Hi, {user?.name}!</Typography>`; `HighlightSpan` import dropped.
- **`theme/theme-light.ts`** — deletes the `HighlightSpan` styled component (its only consumer was the greeting).
- **`index.html`** — deletes the `#markerShape` SVG turbulence filter, which existed solely for the highlight.
- **`DESIGN.md` / `PRODUCT.md`** — updates the brand docs so they no longer promise the marker motif; the brand's human touch now rests on the cheeky copy and intentional use of Flock yellow.

## Verification

- `npx tsc --noEmit` passes.
- `biome check` clean on the changed files (two pre-existing `noExplicitAny` warnings in `HomeFeature.tsx` are untouched).
- `HighlightSpan`, `markerShape`, and `svg-filters` have no remaining references in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUYRB1AAo44p8n7z2biiZW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUYRB1AAo44p8n7z2biiZW)_